### PR TITLE
feat(core): Added support for Defend Dispute (L2) and Adyen Defend Dispute (L3)

### DIFF
--- a/backend/connector-integration/src/connectors/razorpay.rs
+++ b/backend/connector-integration/src/connectors/razorpay.rs
@@ -1,14 +1,14 @@
 pub mod test;
 pub mod transformers;
 use domain_types::{
-    connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void},
+    connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void, DefendDispute},
     connector_types::{
         ConnectorServiceTrait, ConnectorWebhookSecrets, EventType, IncomingWebhook,
         PaymentAuthorizeV2, PaymentCapture, PaymentCreateOrderData, PaymentCreateOrderResponse,
         PaymentFlowData, PaymentOrderCreate, PaymentSyncV2, PaymentVoidData, PaymentVoidV2,
         PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
         RefundFlowData, RefundSyncData, RefundSyncV2, RefundV2, RefundsData, RefundsResponseData,
-        RequestDetails, ValidationTrait, WebhookDetailsResponse,
+        RequestDetails, ValidationTrait, WebhookDetailsResponse, DisputeFlowData, DisputeDefendData, DisputeDefendResponseData, DefendDisputeV2
     },
 };
 use hyperswitch_common_utils::{
@@ -65,6 +65,7 @@ impl PaymentVoidV2 for Razorpay {}
 impl RefundSyncV2 for Razorpay {}
 impl RefundV2 for Razorpay {}
 impl PaymentCapture for Razorpay {}
+impl DefendDisputeV2 for Razorpay {}
 
 impl Razorpay {
     pub const fn new() -> &'static Self {
@@ -732,3 +733,5 @@ impl ConnectorIntegrationV2<Capture, PaymentFlowData, PaymentsCaptureData, Payme
         self.build_error_response(res, event_builder)
     }
 }
+
+impl ConnectorIntegrationV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeDefendResponseData> for Razorpay {}

--- a/backend/domain_types/src/connector_flow.rs
+++ b/backend/domain_types/src/connector_flow.rs
@@ -18,3 +18,6 @@ pub struct Refund;
 
 #[derive(Debug, Clone)]
 pub struct Capture;
+
+#[derive(Debug, Clone)]
+pub struct DefendDispute;

--- a/backend/domain_types/src/connector_types.rs
+++ b/backend/domain_types/src/connector_types.rs
@@ -1,4 +1,4 @@
-use crate::connector_flow::{self, Authorize, Capture, PSync, RSync, Refund, Void};
+use crate::connector_flow::{self, Authorize, Capture, PSync, RSync, Refund, Void, DefendDispute};
 use crate::errors::{ApiError, ApplicationErrorResponse};
 use crate::types::Connectors;
 use crate::utils::ForeignTryFrom;
@@ -49,11 +49,13 @@ pub trait ConnectorServiceTrait:
     + RefundV2
     + PaymentCapture
     + RefundSyncV2
+    + DefendDisputeV2
 {
 }
 
 pub trait PaymentVoidV2:
     ConnectorIntegrationV2<Void, PaymentFlowData, PaymentVoidData, PaymentsResponseData>
+    + DefendDisputeV2
 {
 }
 
@@ -93,6 +95,47 @@ pub trait RefundV2:
 pub trait PaymentCapture:
     ConnectorIntegrationV2<Capture, PaymentFlowData, PaymentsCaptureData, PaymentsResponseData>
 {
+}
+
+
+
+pub trait DefendDisputeV2: ConnectorIntegrationV2<
+DefendDispute,
+DisputeFlowData,
+DisputeDefendData,
+DisputeDefendResponseData,
+>{}
+
+#[derive(Default, Debug, Clone)]
+pub struct DisputeDefendData {
+    pub dispute_id: String,
+    pub connector_dispute_id: String,
+    pub defense_reason_code: String,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DisputeDefendResponseData {
+    pub dispute_status: hyperswitch_api_models::enums::DisputeStatus,
+    pub connector_status: Option<String>,
+}
+
+
+#[derive(Debug, Clone)]
+pub struct DisputeFlowData {
+    // pub merchant_id: hyperswitch_common_utils::id_type::MerchantId,
+    // pub payment_id: String,
+    // pub attempt_id: String,
+    // pub payment_method: hyperswitch_common_enums::enums::PaymentMethod,
+    // pub connector_meta_data: Option<hyperswitch_common_utils::pii::SecretSerdeValue>,
+    // pub amount_captured: Option<i64>,
+    // minor amount for amount framework
+    // pub minor_amount_captured: Option<MinorUnit>,
+    /// Contains a reference ID that should be sent in the connector request
+    pub connector_request_reference_id: String,
+    pub dispute_id: String,
+    pub status: hyperswitch_common_enums::DisputeStatus,
+    pub connectors : Connectors,
+    pub defense_reason_code: String,
 }
 
 #[derive(Debug, Clone)]
@@ -246,6 +289,18 @@ pub struct RefundFlowData {
     pub status: hyperswitch_common_enums::RefundStatus,
     pub refund_id: Option<String>,
     pub connectors: Connectors,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DefendDisputeRequestData {
+    pub dispute_id: String,
+    pub connector_dispute_id: String,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DefendDisputeResponse {
+    pub dispute_status: hyperswitch_common_enums::DisputeStatus,
+    pub connector_status: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -10,6 +10,7 @@ service PaymentService {
   rpc IncomingWebhook(IncomingWebhookRequest) returns (IncomingWebhookResponse);
   rpc Refund(RefundsRequest) returns (RefundsResponse);
   rpc PaymentCapture(PaymentsCaptureRequest) returns (PaymentsCaptureResponse);
+  rpc DefendDispute(DisputeDefendRequest) returns (DisputeDefendResponse);
 }
 
 message PaymentsAuthorizeRequest {
@@ -100,6 +101,21 @@ message PaymentsVoidResponse {
   AttemptStatus status = 8;
   optional string error_code = 4;
   optional string error_message = 5;
+}
+
+message DisputeDefendRequest {
+  string defense_reason_code = 1;
+  string dispute_id = 2;
+  string connector_dispute_id =3;
+  Connector connector = 35;
+  AuthType auth_creds = 34;
+}
+
+message DisputeDefendResponse {
+  DisputeStatus dispute_status = 1;
+  optional string connector_status = 2;
+  optional string error_code = 3;
+  optional string error_message = 4;
 }
 
 message IncomingWebhookRequest {
@@ -460,6 +476,16 @@ enum CaptureMethod {
   MANUAL_MULTIPLE = 2;
   SCHEDULED = 3;
   SEQUENTIAL_AUTOMATIC = 4;
+}
+
+enum DisputeStatus {
+  DISPUTE_OPENED = 0;
+  DISPUTE_EXPIRED = 1;
+  DISPUTE_ACCEPTED = 2;
+  DISPUTE_CANCELLED = 3;
+  DISPUTE_CHALLENGED = 4;
+  DISPUTE_WON = 5;
+  DISPUTE_LOST = 6;
 }
 
 enum FutureUsage {

--- a/config/development.toml
+++ b/config/development.toml
@@ -21,4 +21,5 @@ bypass_proxy_urls = ["localhost", "local"]
 
 [connectors]
 adyen.base_url = "https://checkout-test.adyen.com/"
+adyen.dispute_base_url = "https://ca-test.adyen.com/"
 razorpay.base_url = "https://api.razorpay.com/"


### PR DESCRIPTION
## Description
Added Defend Disputes support in core and also added support for Adyen Defend Disputes

## Motivation and Context


### Additional Changes
- [x] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
Request : 
```
grpcurl -plaintext -d '{
    "defense_reason_code": "AdditionalInformation",
    "dispute_id": "YOUR_CONNECTOR_DISPUTE_ID",
    "connector_dispute_id": "YOUR_CONNECTOR_DISPUTE_ID",
    "connector": "ADYEN",
    "auth_creds": {
    "signature_key": {
      "api_key": "YOUR_ADYEN_API_KEY",
      "key1": "YOUR_ADYEN_KEY1",
      "api_secret": "YOUR_ADYEN_API_SECRET"
    }
  }
}' localhost:8000 ucs.payments.PaymentService/DefendDispute
```

Response: 
```
{
    "dispute_status": "DISPUTE_WON"
}
```
