### PR TITLE
feat(core): Added Defend Dispute flow (L2) and Adyen Defend Dispute(L3)

### DIFF
--- a/backend/connector-integration/src/connectors/adyen.rs
+++ b/backend/connector-integration/src/connectors/adyen.rs
@@ -28,9 +28,10 @@ use hyperswitch_interfaces::{
 use hyperswitch_masking::{Mask, Maskable};
 
 use domain_types::{
-    connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void},
+    connector_flow::{Authorize, Capture, CreateOrder, DefendDispute, PSync, RSync, Refund, Void},
     connector_types::{
-        ConnectorServiceTrait, ConnectorWebhookSecrets, IncomingWebhook, PaymentAuthorizeV2,
+        ConnectorServiceTrait, ConnectorWebhookSecrets, DefendDisputeV2, DisputeDefendData,
+        DisputeDefendResponseData, DisputeFlowData, IncomingWebhook, PaymentAuthorizeV2,
         PaymentCapture, PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
         PaymentOrderCreate, PaymentSyncV2, PaymentVoidData, PaymentVoidV2, PaymentsAuthorizeData,
         PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
@@ -52,6 +53,7 @@ impl PaymentVoidV2 for Adyen {}
 impl RefundSyncV2 for Adyen {}
 impl RefundV2 for Adyen {}
 impl PaymentCapture for Adyen {}
+impl DefendDisputeV2 for Adyen {}
 
 #[derive(Clone)]
 pub struct Adyen {
@@ -632,6 +634,117 @@ impl ConnectorIntegrationV2<Refund, RefundFlowData, RefundsData, RefundsResponse
             .response
             .parse_struct("AdyenRefundResponse")
             .change_context(errors::ConnectorError::ResponseDeserializationFailed)?;
+
+        with_response_body!(event_builder, response);
+
+        RouterDataV2::foreign_try_from((response, data.clone(), res.status_code))
+            .change_context(errors::ConnectorError::ResponseHandlingFailed)
+    }
+
+    fn get_error_response_v2(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+
+    fn get_5xx_error_response(
+        &self,
+        res: Response,
+        event_builder: Option<&mut ConnectorEvent>,
+    ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
+        self.build_error_response(res, event_builder)
+    }
+}
+
+impl
+    ConnectorIntegrationV2<
+        DefendDispute,
+        DisputeFlowData,
+        DisputeDefendData,
+        DisputeDefendResponseData,
+    > for Adyen
+{
+    fn get_headers(
+        &self,
+        req: &RouterDataV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+    ) -> CustomResult<Vec<(String, Maskable<String>)>, errors::ConnectorError>
+    where
+        Self: ConnectorIntegrationV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+    {
+        let mut header = vec![(
+            headers::CONTENT_TYPE.to_string(),
+            "application/json".to_string().into(),
+        )];
+        let mut api_key = self.get_auth_header(&req.connector_auth_type)?;
+        header.append(&mut api_key);
+        Ok(header)
+    }
+
+    fn get_url(
+        &self,
+        req: &RouterDataV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+    ) -> CustomResult<String, errors::ConnectorError> {
+        let adyen_dispute_base_url = req
+            .resource_common_data
+            .connectors
+            .adyen
+            .dispute_base_url
+            .clone()
+            .ok_or(errors::ConnectorError::FailedToObtainIntegrationUrl);
+        Ok(format!("{:?}defendDispute", adyen_dispute_base_url))
+    }
+
+    fn get_request_body(
+        &self,
+        req: &RouterDataV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+    ) -> CustomResult<Option<RequestContent>, errors::ConnectorError> {
+        let connector_req = adyen::AdyenDefendDisputeRequest::try_from(req)?;
+        Ok(Some(RequestContent::Json(Box::new(connector_req))))
+    }
+
+    fn handle_response_v2(
+        &self,
+        data: &RouterDataV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+        event_builder: Option<&mut ConnectorEvent>,
+        res: Response,
+    ) -> CustomResult<
+        RouterDataV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeDefendResponseData>,
+        errors::ConnectorError,
+    > {
+        let response: adyen::AdyenDisputeResponse = res
+            .response
+            .parse_struct("AdyenDisputeResponse")
+            .map_err(|err| {
+                report!(errors::ConnectorError::ResponseDeserializationFailed)
+                    .attach_printable(format!("Failed to parse AdyenDisputeResponse: {err:?}"))
+            })?;
 
         with_response_body!(event_builder, response);
 

--- a/backend/connector-integration/src/connectors/adyen/test.rs
+++ b/backend/connector-integration/src/connectors/adyen/test.rs
@@ -65,9 +65,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "https://sandbox.juspay.in/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                     external_latency: None,
@@ -225,9 +227,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "https://sandbox.juspay.in/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                     external_latency: None,

--- a/backend/connector-integration/src/connectors/adyen/transformers.rs
+++ b/backend/connector-integration/src/connectors/adyen/transformers.rs
@@ -1,12 +1,14 @@
 use domain_types::{
-    connector_flow::{Authorize, Capture, Refund, Void},
+    connector_flow::{Authorize, Capture, DefendDispute, Refund, Void},
     connector_types::{
-        EventType, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
-        PaymentsResponseData, RefundFlowData, RefundsData, RefundsResponseData,
+        DisputeDefendData, DisputeDefendResponseData, DisputeFlowData, EventType, PaymentFlowData,
+        PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData,
+        RefundFlowData, RefundsData, RefundsResponseData,
     },
 };
 use error_stack::ResultExt;
 use hyperswitch_api_models::enums::{self, AttemptStatus, RefundStatus};
+use hyperswitch_common_enums::DisputeStatus;
 
 use hyperswitch_common_utils::{
     errors::CustomResult, ext_traits::ByteSliceExt, request::Method, types::MinorUnit,
@@ -1718,5 +1720,104 @@ impl<F, Req>
             },
             ..data
         })
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdyenDefendDisputeRequest {
+    dispute_psp_reference: String,
+    merchant_account_code: Secret<String>,
+    defense_reason_code: String,
+}
+
+impl
+    TryFrom<
+        &RouterDataV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeDefendResponseData>,
+    > for AdyenDefendDisputeRequest
+{
+    type Error = Error;
+    fn try_from(
+        item: &RouterDataV2<
+            DefendDispute,
+            DisputeFlowData,
+            DisputeDefendData,
+            DisputeDefendResponseData,
+        >,
+    ) -> Result<Self, Self::Error> {
+        let auth_type = AdyenAuthType::try_from(&item.connector_auth_type)?;
+        Ok(Self {
+            dispute_psp_reference: item.request.connector_dispute_id.clone(),
+            merchant_account_code: auth_type.merchant_account.clone(),
+            defense_reason_code: item.request.defense_reason_code.clone(),
+        })
+    }
+}
+
+#[derive(Default, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdyenDisputeResponse {
+    pub dispute_service_result: DisputeServiceResult,
+}
+
+#[derive(Default, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DisputeServiceResult {
+    error_message: Option<String>,
+    success: bool,
+}
+
+impl<F, Req>
+    ForeignTryFrom<(
+        AdyenDisputeResponse,
+        RouterDataV2<F, DisputeFlowData, Req, DisputeDefendResponseData>,
+        u16,
+    )> for RouterDataV2<F, DisputeFlowData, Req, DisputeDefendResponseData>
+{
+    type Error = Error;
+    fn foreign_try_from(
+        (response, data, http_code): (
+            AdyenDisputeResponse,
+            RouterDataV2<F, DisputeFlowData, Req, DisputeDefendResponseData>,
+            u16,
+        ),
+    ) -> Result<Self, Self::Error> {
+        if response.dispute_service_result.success {
+            Ok(Self {
+                response: Ok(DisputeDefendResponseData {
+                    dispute_status: DisputeStatus::DisputeWon,
+                    connector_status: None,
+                }),
+                resource_common_data: DisputeFlowData {
+                    status: hyperswitch_common_enums::DisputeStatus::DisputeWon,
+                    ..data.resource_common_data
+                },
+                ..data
+            })
+        } else {
+            Ok(Self {
+                response: Err(ErrorResponse {
+                    code: response
+                        .dispute_service_result
+                        .error_message
+                        .clone()
+                        .unwrap_or_else(|| NO_ERROR_CODE.to_string()),
+                    message: response
+                        .dispute_service_result
+                        .error_message
+                        .clone()
+                        .unwrap_or_else(|| NO_ERROR_MESSAGE.to_string()),
+                    reason: response.dispute_service_result.error_message.clone(),
+                    status_code: http_code,
+                    attempt_status: None,
+                    connector_transaction_id: None,
+                }),
+                resource_common_data: DisputeFlowData {
+                    status: hyperswitch_common_enums::DisputeStatus::DisputeLost,
+                    ..data.resource_common_data
+                },
+                ..data
+            })
+        }
     }
 }

--- a/backend/connector-integration/src/connectors/razorpay.rs
+++ b/backend/connector-integration/src/connectors/razorpay.rs
@@ -1,14 +1,15 @@
 pub mod test;
 pub mod transformers;
 use domain_types::{
-    connector_flow::{Authorize, Capture, CreateOrder, PSync, RSync, Refund, Void},
+    connector_flow::{Authorize, Capture, CreateOrder, DefendDispute, PSync, RSync, Refund, Void},
     connector_types::{
-        ConnectorServiceTrait, ConnectorWebhookSecrets, EventType, IncomingWebhook,
-        PaymentAuthorizeV2, PaymentCapture, PaymentCreateOrderData, PaymentCreateOrderResponse,
-        PaymentFlowData, PaymentOrderCreate, PaymentSyncV2, PaymentVoidData, PaymentVoidV2,
-        PaymentsAuthorizeData, PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData,
-        RefundFlowData, RefundSyncData, RefundSyncV2, RefundV2, RefundsData, RefundsResponseData,
-        RequestDetails, ValidationTrait, WebhookDetailsResponse,
+        ConnectorServiceTrait, ConnectorWebhookSecrets, DefendDisputeV2, DisputeDefendData,
+        DisputeDefendResponseData, DisputeFlowData, EventType, IncomingWebhook, PaymentAuthorizeV2,
+        PaymentCapture, PaymentCreateOrderData, PaymentCreateOrderResponse, PaymentFlowData,
+        PaymentOrderCreate, PaymentSyncV2, PaymentVoidData, PaymentVoidV2, PaymentsAuthorizeData,
+        PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData,
+        RefundSyncData, RefundSyncV2, RefundV2, RefundsData, RefundsResponseData, RequestDetails,
+        ValidationTrait, WebhookDetailsResponse,
     },
 };
 use hyperswitch_common_utils::{
@@ -65,6 +66,7 @@ impl PaymentVoidV2 for Razorpay {}
 impl RefundSyncV2 for Razorpay {}
 impl RefundV2 for Razorpay {}
 impl PaymentCapture for Razorpay {}
+impl DefendDisputeV2 for Razorpay {}
 
 impl Razorpay {
     pub const fn new() -> &'static Self {
@@ -731,4 +733,14 @@ impl ConnectorIntegrationV2<Capture, PaymentFlowData, PaymentsCaptureData, Payme
     ) -> CustomResult<ErrorResponse, errors::ConnectorError> {
         self.build_error_response(res, event_builder)
     }
+}
+
+impl
+    ConnectorIntegrationV2<
+        DefendDispute,
+        DisputeFlowData,
+        DisputeDefendData,
+        DisputeDefendResponseData,
+    > for Razorpay
+{
 }

--- a/backend/connector-integration/src/connectors/razorpay/test.rs
+++ b/backend/connector-integration/src/connectors/razorpay/test.rs
@@ -94,9 +94,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "https://api.razorpay.com/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -245,9 +247,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: Some("".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -355,9 +359,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: Some("".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -488,9 +494,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "https://api.razorpay.com/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -778,9 +786,11 @@ mod tests {
                 connectors: Connectors {
                     adyen: ConnectorParams {
                         base_url: "https://checkout-test.adyen.com/".to_string(),
+                        dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                     },
                     razorpay: ConnectorParams {
                         base_url: "https://api.razorpay.com/".to_string(),
+                        dispute_base_url: None,
                     },
                 },
             },
@@ -939,9 +949,11 @@ mod tests {
                 connectors: Connectors {
                     adyen: ConnectorParams {
                         base_url: "https://checkout-test.adyen.com/".to_string(),
+                        dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                     },
                     razorpay: ConnectorParams {
                         base_url: "https://api.razorpay.com/".to_string(),
+                        dispute_base_url: None,
                     },
                 },
             },
@@ -1099,9 +1111,11 @@ mod tests {
                     connectors: domain_types::types::Connectors {
                         adyen: domain_types::types::ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: domain_types::types::ConnectorParams {
                             base_url: "https://api.razorpay.com/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -1189,9 +1203,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "https://checkout-test.adyen.com/".to_string(),
+                            dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "https://api.razorpay.com/".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -1285,9 +1301,11 @@ mod tests {
                     connectors: Connectors {
                         adyen: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: Some("".to_string()),
                         },
                         razorpay: ConnectorParams {
                             base_url: "".to_string(),
+                            dispute_base_url: None,
                         },
                     },
                 },
@@ -1420,9 +1438,11 @@ mod tests {
                 connectors: Connectors {
                     adyen: ConnectorParams {
                         base_url: "https://checkout-test.adyen.com/".to_string(),
+                        dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                     },
                     razorpay: ConnectorParams {
                         base_url: "https://api.razorpay.com/".to_string(),
+                        dispute_base_url: None,
                     },
                 },
             },
@@ -1534,9 +1554,11 @@ mod tests {
                 connectors: Connectors {
                     adyen: ConnectorParams {
                         base_url: "https://checkout-test.adyen.com/".to_string(),
+                        dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                     },
                     razorpay: ConnectorParams {
                         base_url: "https://api.razorpay.com/".to_string(),
+                        dispute_base_url: None,
                     },
                 },
             },
@@ -1637,9 +1659,11 @@ mod tests {
                 connectors: Connectors {
                     adyen: ConnectorParams {
                         base_url: "https://checkout-test.adyen.com/".to_string(),
+                        dispute_base_url: Some("https://ca-test.adyen.com/ca/services/DisputeService/v30/defendDispute".to_string()),
                     },
                     razorpay: ConnectorParams {
                         base_url: "https://api.razorpay.com/".to_string(),
+                        dispute_base_url: None
                     },
                 },
             },

--- a/backend/domain_types/src/connector_flow.rs
+++ b/backend/domain_types/src/connector_flow.rs
@@ -18,3 +18,6 @@ pub struct Refund;
 
 #[derive(Debug, Clone)]
 pub struct Capture;
+
+#[derive(Debug, Clone)]
+pub struct DefendDispute;

--- a/backend/domain_types/src/connector_types.rs
+++ b/backend/domain_types/src/connector_types.rs
@@ -1,4 +1,4 @@
-use crate::connector_flow::{self, Authorize, Capture, PSync, RSync, Refund, Void};
+use crate::connector_flow::{self, Authorize, Capture, DefendDispute, PSync, RSync, Refund, Void};
 use crate::errors::{ApiError, ApplicationErrorResponse};
 use crate::types::Connectors;
 use crate::utils::ForeignTryFrom;
@@ -49,6 +49,7 @@ pub trait ConnectorServiceTrait:
     + RefundV2
     + PaymentCapture
     + RefundSyncV2
+    + DefendDisputeV2
 {
 }
 
@@ -438,4 +439,43 @@ pub struct PaymentsCaptureData {
     pub connector_transaction_id: ResponseId,
     pub multiple_capture_data: Option<MultipleCaptureRequestData>,
     pub connector_metadata: Option<serde_json::Value>,
+}
+
+pub trait DefendDisputeV2:
+    ConnectorIntegrationV2<DefendDispute, DisputeFlowData, DisputeDefendData, DisputeDefendResponseData>
+{
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DisputeDefendData {
+    pub dispute_id: String,
+    pub connector_dispute_id: String,
+    pub defense_reason_code: String,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DisputeDefendResponseData {
+    pub dispute_status: hyperswitch_api_models::enums::DisputeStatus,
+    pub connector_status: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisputeFlowData {
+    pub connector_request_reference_id: String,
+    pub dispute_id: String,
+    pub status: hyperswitch_common_enums::DisputeStatus,
+    pub connectors: Connectors,
+    pub defense_reason_code: String,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DefendDisputeRequestData {
+    pub dispute_id: String,
+    pub connector_dispute_id: String,
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct DefendDisputeResponse {
+    pub dispute_status: hyperswitch_common_enums::DisputeStatus,
+    pub connector_status: Option<String>,
 }

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -1,19 +1,20 @@
 use std::borrow::Cow;
 use std::{collections::HashMap, str::FromStr};
 
-use crate::connector_flow::{Authorize, Capture, PSync, RSync, Refund, Void};
+use crate::connector_flow::{Authorize, Capture, DefendDispute, PSync, RSync, Refund, Void};
 use crate::connector_types::{
-    MultipleCaptureRequestData, PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData,
-    PaymentsCaptureData, PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData,
+    DisputeDefendData, DisputeDefendResponseData, DisputeFlowData, MultipleCaptureRequestData,
+    PaymentFlowData, PaymentVoidData, PaymentsAuthorizeData, PaymentsCaptureData,
+    PaymentsResponseData, PaymentsSyncData, RefundFlowData, RefundSyncData,
     RefundWebhookDetailsResponse, RefundsData, RefundsResponseData, WebhookDetailsResponse,
 };
 use crate::errors::{ApiError, ApplicationErrorResponse};
 use crate::utils::{ForeignFrom, ForeignTryFrom};
 use error_stack::{report, ResultExt};
 use grpc_api_types::payments::{
-    PaymentsAuthorizeRequest, PaymentsAuthorizeResponse, PaymentsCaptureResponse,
-    PaymentsSyncResponse, PaymentsVoidRequest, PaymentsVoidResponse, RefundsResponse,
-    RefundsSyncResponse,
+    DisputeDefendRequest, DisputeDefendResponse, PaymentsAuthorizeRequest,
+    PaymentsAuthorizeResponse, PaymentsCaptureResponse, PaymentsSyncResponse, PaymentsVoidRequest,
+    PaymentsVoidResponse, RefundsResponse, RefundsSyncResponse,
 };
 use hyperswitch_common_utils::id_type::CustomerId;
 use hyperswitch_common_utils::pii::Email;
@@ -33,6 +34,7 @@ pub struct Connectors {
 pub struct ConnectorParams {
     /// base url
     pub base_url: String,
+    pub dispute_base_url: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone)]
@@ -1546,5 +1548,69 @@ pub fn generate_payment_capture_response(
                 error_code: Some(e.code),
             })
         }
+    }
+}
+
+impl ForeignTryFrom<(DisputeDefendRequest, Connectors)> for DisputeFlowData {
+    type Error = ApplicationErrorResponse;
+    fn foreign_try_from(
+        (value, connectors): (DisputeDefendRequest, Connectors),
+    ) -> Result<Self, error_stack::Report<Self::Error>> {
+        let connector_dispute_id = value.connector_dispute_id;
+        Ok(Self {
+            dispute_id: connector_dispute_id.clone(),
+            connector_request_reference_id: connector_dispute_id,
+            status: hyperswitch_common_enums::DisputeStatus::DisputeChallenged,
+            connectors,
+            defense_reason_code: value.defense_reason_code,
+        })
+    }
+}
+
+impl ForeignTryFrom<DisputeDefendRequest> for DisputeDefendData {
+    type Error = ApplicationErrorResponse;
+    fn foreign_try_from(
+        value: DisputeDefendRequest,
+    ) -> Result<Self, error_stack::Report<Self::Error>> {
+        let connector_dispute_id = value.connector_dispute_id;
+        Ok(Self {
+            dispute_id: connector_dispute_id.clone(),
+            connector_dispute_id,
+            defense_reason_code: value.defense_reason_code,
+        })
+    }
+}
+
+pub fn generate_defend_dispute_response(
+    router_data_v2: RouterDataV2<
+        DefendDispute,
+        DisputeFlowData,
+        DisputeDefendData,
+        DisputeDefendResponseData,
+    >,
+) -> Result<DisputeDefendResponse, error_stack::Report<ApplicationErrorResponse>> {
+    let dispute_response = router_data_v2.response;
+
+    let grpc_status = if router_data_v2.resource_common_data.status
+        == hyperswitch_common_enums::DisputeStatus::DisputeWon
+    {
+        grpc_api_types::payments::DisputeStatus::DisputeWon
+    } else {
+        grpc_api_types::payments::DisputeStatus::DisputeLost
+    };
+
+    match dispute_response {
+        Ok(response) => Ok(DisputeDefendResponse {
+            dispute_status: grpc_status.into(),
+            connector_status: response.connector_status,
+            error_code: None,
+            error_message: None,
+        }),
+        Err(e) => Ok(DisputeDefendResponse {
+            dispute_status: grpc_status.into(),
+            connector_status: None,
+            error_code: Some(e.code),
+            error_message: Some(e.message),
+        }),
     }
 }

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -10,6 +10,29 @@ service PaymentService {
   rpc IncomingWebhook(IncomingWebhookRequest) returns (IncomingWebhookResponse);
   rpc Refund(RefundsRequest) returns (RefundsResponse);
   rpc PaymentCapture(PaymentsCaptureRequest) returns (PaymentsCaptureResponse);
+  rpc DefendDispute(DisputeDefendRequest) returns (DisputeDefendResponse);
+}
+
+message DisputeDefendRequest {
+  string defense_reason_code = 1;
+  string connector_dispute_id =3;
+}
+
+message DisputeDefendResponse {
+  DisputeStatus dispute_status = 1;
+  optional string connector_status = 2;
+  optional string error_code = 3;
+  optional string error_message = 4;
+}
+
+enum DisputeStatus {
+  DISPUTE_OPENED = 0;
+  DISPUTE_EXPIRED = 1;
+  DISPUTE_ACCEPTED = 2;
+  DISPUTE_CANCELLED = 3;
+  DISPUTE_CHALLENGED = 4;
+  DISPUTE_WON = 5;
+  DISPUTE_LOST = 6;
 }
 
 message PaymentsAuthorizeRequest {

--- a/config/development.toml
+++ b/config/development.toml
@@ -21,4 +21,5 @@ bypass_proxy_urls = ["localhost", "local"]
 
 [connectors]
 adyen.base_url = "https://checkout-test.adyen.com/"
+adyen.dispute_base_url = "https://ca-test.adyen.com/ca/services/DisputeService/v30/"
 razorpay.base_url = "https://api.razorpay.com/"


### PR DESCRIPTION
## Description
Added Defend Disputes support in core and also added support for Adyen Defend Disputes

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [x] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
cURL: 

```
grpcurl -plaintext \
  -H 'x-connector: adyen' \
  -H 'x-auth: signature-key' \
  -H 'x-api-key: YOUR_ADYEN_API_KEY' \
  -H 'x-key1: YOUR_ADYEN_KEY1' \
  -H 'x-api-secret: YOUR_ADYEN_API_SECRET' \
  -d '{
    "defense_reason_code": "AdditionalInformation",
    "connector_dispute_id": "GRB25B7NJBFMNB75"
}' \
  localhost:8000 ucs.payments.PaymentService/DefendDispute
```

Response: 

```
{
  "disputeStatus": "DISPUTE_LOST",
  "connectorDisputeId": "GRB25B7NJBFMNB75"
}
```

Note: To get a connector_dispute_id(pspReference), you will have to receive a webhook from Adyen
https://docs.adyen.com/risk-management/disputes-api/test-applicable-dispute-reasons/
Adyen Dispute API Developer Docs : https://docs.adyen.com/api-explorer/Disputes/latest/post/defendDispute