### PR TITLE
feat: add macro implementations for granular apis in L2 layer

### DIFF
--- a/backend/grpc-server/src/server/payments.rs
+++ b/backend/grpc-server/src/server/payments.rs
@@ -1,4 +1,4 @@
-use crate::implement_payment_operation;
+use crate::implement_connector_operation;
 use crate::{
     configs::Config,
     error::{IntoGrpcStatus, ReportSwitchExt, ResultExtGrpc},
@@ -198,7 +198,7 @@ impl Payments {
 }
 
 impl PaymentOperationsInternal for Payments {
-    implement_payment_operation!(
+    implement_connector_operation!(
         fn_name: internal_payment_sync,
         log_prefix: "PAYMENT_SYNC",
         request_type: PaymentsSyncRequest,
@@ -212,7 +212,7 @@ impl PaymentOperationsInternal for Payments {
         generate_response_fn: generate_payment_sync_response
     );
 
-    implement_payment_operation!(
+    implement_connector_operation!(
         fn_name: internal_refund_sync,
         log_prefix: "REFUND_SYNC",
         request_type: RefundsSyncRequest,
@@ -226,7 +226,7 @@ impl PaymentOperationsInternal for Payments {
         generate_response_fn: generate_refund_sync_response
     );
 
-    implement_payment_operation!(
+    implement_connector_operation!(
         fn_name: internal_void_payment,
         log_prefix: "PAYMENT_VOID",
         request_type: PaymentsVoidRequest,
@@ -240,7 +240,7 @@ impl PaymentOperationsInternal for Payments {
         generate_response_fn: generate_payment_void_response
     );
 
-    implement_payment_operation!(
+    implement_connector_operation!(
         fn_name: internal_refund,
         log_prefix: "REFUND",
         request_type: RefundsRequest,
@@ -254,7 +254,7 @@ impl PaymentOperationsInternal for Payments {
         generate_response_fn: generate_refund_response
     );
 
-    implement_payment_operation!(
+    implement_connector_operation!(
         fn_name: internal_payment_capture,
         log_prefix: "PAYMENT_CAPTURE",
         request_type: PaymentsCaptureRequest,

--- a/backend/grpc-server/src/server/payments.rs
+++ b/backend/grpc-server/src/server/payments.rs
@@ -1,3 +1,4 @@
+use crate::implement_payment_operation;
 use crate::{
     configs::Config,
     error::{IntoGrpcStatus, ReportSwitchExt, ResultExtGrpc},
@@ -71,83 +72,6 @@ trait PaymentOperationsInternal {
         &self,
         request: tonic::Request<PaymentsCaptureRequest>,
     ) -> Result<tonic::Response<PaymentsCaptureResponse>, tonic::Status>;
-}
-
-macro_rules! implement_payment_operation {
-    (
-        fn_name: $fn_name:ident,
-        log_prefix: $log_prefix:literal,
-        request_type: $request_type:ty,
-        response_type: $response_type:ty,
-        flow_marker: $flow_marker:ty,
-        resource_common_data_type: $resource_common_data_type:ty,
-        request_data_type: $request_data_type:ty,
-        response_data_type: $response_data_type:ty,
-        request_data_constructor: $request_data_constructor:path,
-        common_flow_data_constructor: $common_flow_data_constructor:path,
-        generate_response_fn: $generate_response_fn:path
-    ) => {
-        async fn $fn_name(
-            &self,
-            request: tonic::Request<$request_type>,
-        ) -> Result<tonic::Response<$response_type>, tonic::Status> {
-            info!(concat!($log_prefix, "_FLOW: initiated"));
-
-            let connector = crate::utils::connector_from_metadata(request.metadata()).into_grpc_status()?;
-            let connector_auth_details = crate::utils::auth_from_metadata(request.metadata()).into_grpc_status()?;
-            let payload = request.into_inner();
-
-            // Get connector data
-            let connector_data = connector_integration::types::ConnectorData::get_connector_by_name(&connector);
-
-            // Get connector integration
-            let connector_integration: hyperswitch_interfaces::connector_integration_v2::BoxedConnectorIntegrationV2<
-                '_,
-                $flow_marker,
-                $resource_common_data_type,
-                $request_data_type,
-                $response_data_type,
-            > = connector_data.connector.get_connector_integration_v2();
-
-            // Create connector request data
-            let specific_request_data = $request_data_constructor(payload.clone())
-                .into_grpc_status()?;
-
-            // Create common request data
-            let common_flow_data = $common_flow_data_constructor((payload.clone(), self.config.connectors.clone()))
-                .into_grpc_status()?;
-
-            // Create router data
-            let router_data = hyperswitch_domain_models::router_data_v2::RouterDataV2::<
-                $flow_marker,
-                $resource_common_data_type,
-                $request_data_type,
-                $response_data_type,
-            > {
-                flow: std::marker::PhantomData,
-                resource_common_data: common_flow_data,
-                connector_auth_type: connector_auth_details,
-                request: specific_request_data,
-                response: Err(hyperswitch_domain_models::router_data::ErrorResponse::default()),
-            };
-
-            // Execute connector processing
-            let response_result = external_services::service::execute_connector_processing_step(
-                &self.config.proxy,
-                connector_integration,
-                router_data,
-            )
-            .await
-            .switch()
-            .into_grpc_status()?;
-
-            // Generate response
-            let final_response = $generate_response_fn(response_result)
-                .into_grpc_status()?;
-
-            Ok(tonic::Response::new(final_response))
-        }
-    };
 }
 
 pub struct Payments {

--- a/backend/grpc-server/src/utils.rs
+++ b/backend/grpc-server/src/utils.rs
@@ -119,3 +119,81 @@ fn parse_metadata<'a>(
             })
         })
 }
+
+#[macro_export]
+macro_rules! implement_payment_operation {
+    (
+        fn_name: $fn_name:ident,
+        log_prefix: $log_prefix:literal,
+        request_type: $request_type:ty,
+        response_type: $response_type:ty,
+        flow_marker: $flow_marker:ty,
+        resource_common_data_type: $resource_common_data_type:ty,
+        request_data_type: $request_data_type:ty,
+        response_data_type: $response_data_type:ty,
+        request_data_constructor: $request_data_constructor:path,
+        common_flow_data_constructor: $common_flow_data_constructor:path,
+        generate_response_fn: $generate_response_fn:path
+    ) => {
+        async fn $fn_name(
+            &self,
+            request: tonic::Request<$request_type>,
+        ) -> Result<tonic::Response<$response_type>, tonic::Status> {
+            tracing::info!(concat!($log_prefix, "_FLOW: initiated"));
+
+            let connector = $crate::utils::connector_from_metadata(request.metadata()).into_grpc_status()?;
+            let connector_auth_details = $crate::utils::auth_from_metadata(request.metadata()).into_grpc_status()?;
+            let payload = request.into_inner();
+
+            // Get connector data
+            let connector_data = connector_integration::types::ConnectorData::get_connector_by_name(&connector);
+
+            // Get connector integration
+            let connector_integration: hyperswitch_interfaces::connector_integration_v2::BoxedConnectorIntegrationV2<
+                '_,
+                $flow_marker,
+                $resource_common_data_type,
+                $request_data_type,
+                $response_data_type,
+            > = connector_data.connector.get_connector_integration_v2();
+
+            // Create connector request data
+            let specific_request_data = $request_data_constructor(payload.clone())
+                .into_grpc_status()?;
+
+            // Create common request data
+            let common_flow_data = $common_flow_data_constructor((payload.clone(), self.config.connectors.clone()))
+                .into_grpc_status()?;
+
+            // Create router data
+            let router_data = hyperswitch_domain_models::router_data_v2::RouterDataV2::<
+                $flow_marker,
+                $resource_common_data_type,
+                $request_data_type,
+                $response_data_type,
+            > {
+                flow: std::marker::PhantomData,
+                resource_common_data: common_flow_data,
+                connector_auth_type: connector_auth_details,
+                request: specific_request_data,
+                response: Err(hyperswitch_domain_models::router_data::ErrorResponse::default()),
+            };
+
+            // Execute connector processing
+            let response_result = external_services::service::execute_connector_processing_step(
+                &self.config.proxy,
+                connector_integration,
+                router_data,
+            )
+            .await
+            .switch()
+            .into_grpc_status()?;
+
+            // Generate response
+            let final_response = $generate_response_fn(response_result)
+                .into_grpc_status()?;
+
+            Ok(tonic::Response::new(final_response))
+        }
+    };
+}

--- a/backend/grpc-server/src/utils.rs
+++ b/backend/grpc-server/src/utils.rs
@@ -121,7 +121,7 @@ fn parse_metadata<'a>(
 }
 
 #[macro_export]
-macro_rules! implement_payment_operation {
+macro_rules! implement_connector_operation {
     (
         fn_name: $fn_name:ident,
         log_prefix: $log_prefix:literal,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add macro implementations for granular apis in L2 layer

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->
This PR addresses significant code duplication across five core gRPC service methods (payment_sync, refund_sync, void_payment, refund, payment_capture) in payments.rs. The goal is to enhance maintainability, readability, and reduce boilerplate by centralizing their common request processing logic.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Tested Manually

Payment Sync
![image](https://github.com/user-attachments/assets/41bd596d-fe24-4189-9c33-0031f547340c)
