### PR TITLE
feat: add all_keys_required and raw_connector_response

### DIFF
--- a/backend/connector-integration/src/connectors/adyen/test.rs
+++ b/backend/connector-integration/src/connectors/adyen/test.rs
@@ -73,6 +73,7 @@ mod tests {
                         },
                     },
                     external_latency: None,
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: Secret::new(api_key),
@@ -147,6 +148,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse::default()),
             };
@@ -235,6 +237,7 @@ mod tests {
                         },
                     },
                     external_latency: None,
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: Secret::new(api_key),
@@ -272,6 +275,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse::default()),
             };

--- a/backend/connector-integration/src/connectors/adyen/transformers.rs
+++ b/backend/connector-integration/src/connectors/adyen/transformers.rs
@@ -956,6 +956,7 @@ impl
             connector_response_reference_id: Some(response.reference),
             incremental_authorization_allowed: None,
             mandate_reference: Box::new(None),
+            raw_connector_response: None,
         };
 
         Ok(Self {
@@ -1025,6 +1026,7 @@ pub fn get_adyen_response(
         connector_response_reference_id: Some(response.merchant_reference),
         incremental_authorization_allowed: None,
         mandate_reference: Box::new(mandate_reference),
+        raw_connector_response: None,
     };
     Ok((status, error, payments_response_data))
 }
@@ -1095,6 +1097,7 @@ pub fn get_redirection_response(
             .or(response.psp_reference),
         incremental_authorization_allowed: None,
         mandate_reference: Box::new(None),
+        raw_connector_response: None,
     };
     Ok((status, error, payments_response_data))
 }
@@ -1746,6 +1749,7 @@ impl<F, Req>
                 connector_response_reference_id: Some(response.reference),
                 incremental_authorization_allowed: None,
                 mandate_reference: Box::new(None),
+                raw_connector_response: None,
             }),
             resource_common_data: PaymentFlowData {
                 // From the docs, the only value returned is "received", outcome of refund is available

--- a/backend/connector-integration/src/connectors/razorpay/test.rs
+++ b/backend/connector-integration/src/connectors/razorpay/test.rs
@@ -101,6 +101,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -165,6 +166,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse {
                     code: "HE_00".to_string(),
@@ -254,6 +256,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -302,6 +305,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse {
                     code: "HE_01".to_string(),
@@ -366,6 +370,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -414,6 +419,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse {
                     code: "HE_02".to_string(),
@@ -501,6 +507,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -565,6 +572,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse {
                     code: "HE_00".to_string(),
@@ -793,6 +801,7 @@ mod tests {
                         dispute_base_url: None,
                     },
                 },
+                raw_connector_response: None,
             },
             connector_auth_type: ConnectorAuthType::BodyKey {
                 api_key: "dummy_api_key".to_string().into(),
@@ -855,6 +864,7 @@ mod tests {
                 shipping_cost: None,
                 merchant_account_id: None,
                 merchant_config_currency: None,
+                all_keys_required: None,
             },
             response: Err(ErrorResponse {
                 code: "HE_00".to_string(),
@@ -956,6 +966,7 @@ mod tests {
                         dispute_base_url: None,
                     },
                 },
+                raw_connector_response: None,
             },
             connector_auth_type: ConnectorAuthType::BodyKey {
                 api_key: "dummy_api_key".to_string().into(),
@@ -1018,6 +1029,7 @@ mod tests {
                 shipping_cost: None,
                 merchant_account_id: None,
                 merchant_config_currency: None,
+                all_keys_required: None,
             },
             response: Err(ErrorResponse {
                 code: "HE_00".to_string(),
@@ -1118,6 +1130,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -1210,6 +1223,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "dummy_api_key".to_string().into(),
@@ -1308,6 +1322,7 @@ mod tests {
                             dispute_base_url: None,
                         },
                     },
+                    raw_connector_response: None,
                 },
                 connector_auth_type: ConnectorAuthType::BodyKey {
                     api_key: "invalid_key".to_string().into(),
@@ -1356,6 +1371,7 @@ mod tests {
                     shipping_cost: None,
                     merchant_account_id: None,
                     merchant_config_currency: None,
+                    all_keys_required: None,
                 },
                 response: Err(ErrorResponse {
                     code: "HE_INVALID".to_string(),
@@ -1445,6 +1461,7 @@ mod tests {
                         dispute_base_url: None,
                     },
                 },
+                raw_connector_response: None,
             },
             connector_auth_type: ConnectorAuthType::BodyKey {
                 api_key: "dummy_api_key".to_string().into(),
@@ -1561,6 +1578,7 @@ mod tests {
                         dispute_base_url: None,
                     },
                 },
+                raw_connector_response: None,
             },
             connector_auth_type: ConnectorAuthType::BodyKey {
                 api_key: "dummy_api_key".to_string().into(),
@@ -1666,6 +1684,7 @@ mod tests {
                         dispute_base_url: None,
                     },
                 },
+                raw_connector_response: None,
             },
             connector_auth_type: ConnectorAuthType::BodyKey {
                 api_key: "dummy_api_key".to_string().into(),

--- a/backend/connector-integration/src/connectors/razorpay/transformers.rs
+++ b/backend/connector-integration/src/connectors/razorpay/transformers.rs
@@ -722,6 +722,7 @@ impl<F, Req>
                     connector_response_reference_id: None,
                     incremental_authorization_allowed: None,
                     mandate_reference: Box::new(None),
+                    raw_connector_response: None,
                 };
                 let error = None;
 
@@ -745,6 +746,7 @@ impl<F, Req>
                     connector_response_reference_id: None,
                     incremental_authorization_allowed: None,
                     mandate_reference: Box::new(None),
+                    raw_connector_response: None,
                 };
                 let error = None;
 
@@ -1150,6 +1152,7 @@ impl<F, Req>
                 connector_response_reference_id: Some(response.order_id),
                 incremental_authorization_allowed: None,
                 mandate_reference: Box::new(None),
+                raw_connector_response: None,
             }),
             resource_common_data: PaymentFlowData {
                 status,

--- a/backend/domain_types/src/connector_types.rs
+++ b/backend/domain_types/src/connector_types.rs
@@ -125,6 +125,10 @@ pub trait SubmitEvidenceV2:
 {
 }
 
+pub trait RawConnectorResponse {
+    fn set_raw_connector_response(&mut self, response: Option<String>);
+}
+
 #[derive(Debug, Clone)]
 pub struct PaymentFlowData {
     pub merchant_id: hyperswitch_common_utils::id_type::MerchantId,
@@ -155,7 +159,15 @@ pub struct PaymentFlowData {
     pub connector_http_status_code: Option<u16>,
     pub external_latency: Option<u128>,
     pub connectors: Connectors,
+    pub raw_connector_response: Option<String>,
 }
+
+impl RawConnectorResponse for PaymentFlowData {
+    fn set_raw_connector_response(&mut self, response: Option<String>) {
+        self.raw_connector_response = response;
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PaymentVoidData {
     pub connector_transaction_id: String,
@@ -208,6 +220,7 @@ pub struct PaymentsAuthorizeData {
     pub shipping_cost: Option<MinorUnit>,
     pub merchant_account_id: Option<String>,
     pub merchant_config_currency: Option<hyperswitch_common_enums::Currency>,
+    pub all_keys_required: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -222,6 +235,7 @@ pub struct PaymentsSyncData {
     pub currency: hyperswitch_common_enums::Currency,
     pub payment_experience: Option<hyperswitch_common_enums::PaymentExperience>,
     pub amount: MinorUnit,
+    pub all_keys_required: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -256,6 +270,7 @@ pub enum PaymentsResponseData {
         network_txn_id: Option<String>,
         connector_response_reference_id: Option<String>,
         incremental_authorization_allowed: Option<bool>,
+        raw_connector_response: Option<String>,
     },
     SessionResponse {
         session_token: String,
@@ -299,6 +314,10 @@ pub struct RefundFlowData {
     pub status: hyperswitch_common_enums::RefundStatus,
     pub refund_id: Option<String>,
     pub connectors: Connectors,
+}
+
+impl RawConnectorResponse for RefundFlowData {
+    fn set_raw_connector_response(&mut self, _response: Option<String>) {}
 }
 
 #[derive(Debug, Clone)]
@@ -531,6 +550,10 @@ pub struct DisputeFlowData {
     pub dispute_id: Option<String>,
     pub connector_dispute_id: String,
     pub connectors: Connectors,
+}
+
+impl RawConnectorResponse for DisputeFlowData {
+    fn set_raw_connector_response(&mut self, _response: Option<String>) {}
 }
 
 #[derive(Debug, Clone)]

--- a/backend/domain_types/src/types.rs
+++ b/backend/domain_types/src/types.rs
@@ -371,6 +371,7 @@ impl ForeignTryFrom<PaymentsAuthorizeRequest> for PaymentsAuthorizeData {
             shipping_cost: None,
             merchant_account_id: None,
             merchant_config_currency: None,
+            all_keys_required: value.all_keys_required,
         })
     }
 }
@@ -803,6 +804,7 @@ impl ForeignTryFrom<(PaymentsAuthorizeRequest, Connectors)> for PaymentFlowData 
             connector_http_status_code: None,
             external_latency: None,
             connectors,
+            raw_connector_response: None,
         })
     }
 }
@@ -846,6 +848,7 @@ impl ForeignTryFrom<(PaymentsVoidRequest, Connectors)> for PaymentFlowData {
             connector_http_status_code: None,
             external_latency: None,
             connectors,
+            raw_connector_response: None,
         })
     }
 }
@@ -890,6 +893,7 @@ pub fn generate_payment_authorize_response(
                 connector_response_reference_id,
                 incremental_authorization_allowed,
                 mandate_reference: _,
+                raw_connector_response: _,
             } => {
                 PaymentsAuthorizeResponse {
                     resource_id: Some(grpc_api_types::payments::ResponseId::foreign_try_from(resource_id)?),
@@ -933,6 +937,7 @@ pub fn generate_payment_authorize_response(
                     mandate_reference: None, //TODO
                     error_message: None,
                     error_code: None,
+                    raw_connector_response: router_data_v2.resource_common_data.raw_connector_response.clone(),
                 }
             }
             _ => Err(ApplicationErrorResponse::BadRequest(ApiError {
@@ -961,6 +966,10 @@ pub fn generate_payment_authorize_response(
                 status: status as i32,
                 error_message: Some(err.message),
                 error_code: Some(err.code),
+                raw_connector_response: router_data_v2
+                    .resource_common_data
+                    .raw_connector_response
+                    .clone(),
             }
         }
     };
@@ -995,6 +1004,7 @@ impl ForeignTryFrom<grpc_api_types::payments::PaymentsSyncRequest> for PaymentsS
             currency,
             payment_experience: None,
             amount,
+            all_keys_required: value.all_keys_required,
         })
     }
 }
@@ -1035,6 +1045,7 @@ impl ForeignTryFrom<(grpc_api_types::payments::PaymentsSyncRequest, Connectors)>
             connector_http_status_code: None,
             external_latency: None,
             connectors,
+            raw_connector_response: None,
         })
     }
 }
@@ -1119,6 +1130,7 @@ pub fn generate_payment_void_response(
                 connector_response_reference_id,
                 incremental_authorization_allowed: _,
                 mandate_reference: _,
+                raw_connector_response: _,
             } => {
                 let status = router_data_v2.resource_common_data.status;
                 let grpc_status = grpc_api_types::payments::AttemptStatus::foreign_from(status);
@@ -1178,6 +1190,7 @@ pub fn generate_payment_sync_response(
                 connector_response_reference_id,
                 incremental_authorization_allowed: _,
                 mandate_reference: _,
+                raw_connector_response: _,
             } => {
                 let status = router_data_v2.resource_common_data.status;
                 let grpc_status = grpc_api_types::payments::AttemptStatus::foreign_from(status);
@@ -1195,6 +1208,10 @@ pub fn generate_payment_sync_response(
                     connector_response_reference_id,
                     error_code: None,
                     error_message: None,
+                    raw_connector_response: router_data_v2
+                        .resource_common_data
+                        .raw_connector_response
+                        .clone(),
                 })
             }
             _ => Err(report!(ApplicationErrorResponse::InternalServerError(
@@ -1223,6 +1240,10 @@ pub fn generate_payment_sync_response(
                 status: status as i32,
                 error_message: Some(e.message),
                 error_code: Some(e.code),
+                raw_connector_response: router_data_v2
+                    .resource_common_data
+                    .raw_connector_response
+                    .clone(),
             })
         }
     }
@@ -1446,6 +1467,7 @@ impl ForeignTryFrom<WebhookDetailsResponse> for PaymentsSyncResponse {
             connector_response_reference_id: value.connector_response_reference_id,
             error_code: value.error_code,
             error_message: value.error_message,
+            raw_connector_response: None,
         })
     }
 }
@@ -1684,6 +1706,7 @@ impl ForeignTryFrom<(grpc_api_types::payments::PaymentsCaptureRequest, Connector
             connector_http_status_code: None,
             external_latency: None,
             connectors,
+            raw_connector_response: None,
         })
     }
 }
@@ -1708,6 +1731,7 @@ pub fn generate_payment_capture_response(
                 connector_response_reference_id,
                 incremental_authorization_allowed: _,
                 mandate_reference: _,
+                raw_connector_response: _,
             } => {
                 let status = router_data_v2.resource_common_data.status;
                 let grpc_status = grpc_api_types::payments::AttemptStatus::foreign_from(status);
@@ -1798,6 +1822,7 @@ impl ForeignTryFrom<(SetupMandateRequest, Connectors)> for PaymentFlowData {
             connector_http_status_code: None,
             external_latency: None,
             connectors,
+            raw_connector_response: None,
         })
     }
 }
@@ -1971,6 +1996,7 @@ pub fn generate_setup_mandate_response(
                 connector_response_reference_id,
                 incremental_authorization_allowed,
                 mandate_reference,
+                raw_connector_response: _,
             } => {
                 SetupMandateResponse {
                     resource_id: Some(grpc_api_types::payments::ResponseId::foreign_try_from(resource_id)?),

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -144,7 +144,7 @@ where
 
                             match handle_response_result {
                                 Ok(mut data) => {
-                                    if all_keys_required == Some(true) {
+                                    if all_keys_required.unwrap_or(false) {
                                         let raw_response_string =
                                             String::from_utf8(body.response.to_vec()).ok();
                                         data.resource_common_data

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -16,6 +16,7 @@ use serde_json::json;
 use std::{str::FromStr, time::Duration};
 use tracing::field::Empty;
 
+use domain_types::connector_types::RawConnectorResponse;
 use hyperswitch_interfaces::{
     connector_integration_v2::BoxedConnectorIntegrationV2, errors::ConnectorError, types::Response,
 };
@@ -27,12 +28,13 @@ pub async fn execute_connector_processing_step<F, ResourceCommonData, Req, Resp>
     proxy: &Proxy,
     connector: BoxedConnectorIntegrationV2<'static, F, ResourceCommonData, Req, Resp>,
     router_data: RouterDataV2<F, ResourceCommonData, Req, Resp>,
+    all_keys_required: Option<bool>,
 ) -> CustomResult<RouterDataV2<F, ResourceCommonData, Req, Resp>, ConnectorError>
 where
     F: Clone + 'static,
     Req: Clone + 'static + std::fmt::Debug,
     Resp: Clone + 'static + std::fmt::Debug,
-    ResourceCommonData: Clone + 'static,
+    ResourceCommonData: Clone + 'static + RawConnectorResponse,
 {
     let span = tracing::info_span!(
         "ucs_outgoing_app_data",
@@ -141,7 +143,15 @@ where
                                 connector.handle_response_v2(&router_data, None, body.clone());
 
                             match handle_response_result {
-                                Ok(data) => Ok(data),
+                                Ok(mut data) => {
+                                    if all_keys_required == Some(true) {
+                                        let raw_response_string =
+                                            String::from_utf8(body.response.to_vec()).ok();
+                                        data.resource_common_data
+                                            .set_raw_connector_response(raw_response_string);
+                                    }
+                                    Ok(data)
+                                }
                                 Err(err) => Err(err),
                             }?
                         }

--- a/backend/grpc-api-types/proto/payment.proto
+++ b/backend/grpc-api-types/proto/payment.proto
@@ -49,6 +49,7 @@ AuthenticationType auth_type = 4;
   int64 minor_amount = 31;
   optional string merchant_order_reference_id = 32;
   optional int64 shipping_cost = 33;
+  optional bool all_keys_required = 34;
 }
 
 message PaymentsAuthorizeResponse {
@@ -61,11 +62,13 @@ message PaymentsAuthorizeResponse {
   AttemptStatus status = 8;
   optional string error_code = 9;
   optional string error_message = 10;
+  optional string raw_connector_response = 11;
 }
 
 message PaymentsSyncRequest {
   string resource_id = 1;
   optional string connector_request_reference_id = 2;
+  optional bool all_keys_required = 3;
 }
 
 message PaymentsSyncResponse {
@@ -76,6 +79,7 @@ message PaymentsSyncResponse {
   optional string connector_response_reference_id = 5;
   optional string error_code = 9;
   optional string error_message = 10;
+  optional string raw_connector_response = 11;
 }
 
 message RefundsSyncRequest {

--- a/backend/grpc-server/src/server/payments.rs
+++ b/backend/grpc-server/src/server/payments.rs
@@ -92,6 +92,7 @@ impl Payments {
             &self.config.proxy,
             connector_integration,
             order_router_data,
+            None,
         )
         .await
         .switch()
@@ -150,6 +151,7 @@ impl Payments {
             &self.config.proxy,
             connector_integration,
             order_router_data,
+            None,
         )
         .await
         .switch()
@@ -233,6 +235,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            payload.all_keys_required,
         )
         .await
         .switch()
@@ -292,6 +295,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            payload.all_keys_required,
         )
         .await
         .switch()
@@ -350,6 +354,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -406,6 +411,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -545,6 +551,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -603,6 +610,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -676,6 +684,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -734,6 +743,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()
@@ -790,6 +800,7 @@ impl PaymentService for Payments {
             &self.config.proxy,
             connector_integration,
             router_data,
+            None,
         )
         .await
         .switch()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Added `all_keys_required` and `raw_connector_response`

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

Authorize Curl:

```
grpcurl -plaintext \
-H 'x-connector: adyen' \
-H 'x-auth: signature-key' \
-H 'x-api-key: *** \
-H 'x-key1: *** \
-H 'x-api-secret: *** \
-d '{
 "amount": 1000,
 "currency": "USD",
 "payment_method": "CARD",
 "payment_method_data": {
  "card": {
   "card_number": "4166676667666746",
   "card_exp_month": "03",
   "card_exp_year": "2030",
   "card_cvc": "737"
  }
 },
 "connector_customer": "abc123",
 "return_url": "www.google.com",
 "address": {},
 "auth_type": "THREE_DS",
 "all_keys_required": true,
 "connector_request_reference_id": "ref_12345",
 "enrolled_for_3ds": true,
 "request_incremental_authorization": false,
 "minor_amount": 1000,
 "browser_info": {
  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
  "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
  "language": "en-US",
  "color_depth": 24,
  "screen_height": 1080,
  "screen_width": 1920,
  "java_enabled": false
 }
}' localhost:8000 ucs.payments.PaymentService/PaymentAuthorize
```

Response:

```
{
  "resourceId": {
    "connectorTransactionId": "X54XFPWZGDQH7RV5"
  },
  "networkTxnId": "609072443363782",
  "connectorResponseReferenceId": "ref_12345",
  "status": "CHARGED",
  "rawConnectorResponse": "{\"additionalData\":{\"scaExemptionRequested\":\"lowValue\",\"refusalReasonRaw\":\"AUTHORISED\",\"eci\":\"N\\/A\",\"acquirerAccountCode\":\"TestPmmAcquirerAccount\",\"xid\":\"N\\/A\",\"threeDAuthenticated\":\"false\",\"paymentMethodVariant\":\"visacredit\",\"issuerBin\":\"41666766\",\"threeDOffered\":\"false\",\"threeDOfferedResponse\":\"N\\/A\",\"authorisationMid\":\"50\",\"bankAccount.iban\":null,\"cavv\":\"N\\/A\",\"bankAccount.ownerName\":null,\"authorisedAmountCurrency\":\"USD\",\"threeDAuthenticatedResponse\":\"N\\/A\",\"avsResultRaw\":\"4\",\"retry.attempt1.rawResponse\":\"AUTHORISED\",\"paymentMethod\":\"visa\",\"fundingSource\":\"CREDIT\",\"retry.attempt1.scaExemptionRequested\":\"lowValue\",\"avsResult\":\"4 AVS not supported for this card type\",\"cardSummary\":\"6746\",\"retry.attempt1.avsResultRaw\":\"4\",\"networkTxReference\":\"609072443363782\",\"expiryDate\":\"3\\/2030\",\"cavvAlgorithm\":\"N\\/A\",\"cardBin\":\"416667\",\"alias\":\"A180363829982701\",\"cvcResultRaw\":\"M\",\"merchantReference\":\"ref_12345\",\"acquirerReference\":\"R5437H85S87\",\"cardIssuingCountry\":\"NL\",\"liabilityShift\":\"false\",\"authCode\":\"087279\",\"cardHolderName\":\"Checkout Shopper PlaceHolder\",\"isCardCommercial\":\"unknown\",\"PaymentAccountReference\":\"wj4hJNSkfyxKG5zX5zuODWWxn7YR0\",\"retry.attempt1.acquirerAccount\":\"TestPmmAcquirerAccount\",\"retry.attempt1.acquirer\":\"TestPmmAcquirer\",\"authorisedAmountValue\":\"1000\",\"issuerCountry\":\"NL\",\"cvcResult\":\"1 Matches\",\"retry.attempt1.responseCode\":\"Approved\",\"aliasType\":\"Default\",\"retry.attempt1.shopperInteraction\":\"Ecommerce\",\"cardPaymentMethod\":\"visacredit\",\"acquirerCode\":\"TestPmmAcquirer\"},\"pspReference\":\"X54XFPWZGDQH7RV5\",\"resultCode\":\"Authorised\",\"amount\":{\"currency\":\"USD\",\"value\":1000},\"merchantReference\":\"ref_12345\"}"
}
```
