### PR TITLE
fix(config): add list parse key for proxy.bypass_proxy_urls environment variable

### DIFF
--- a/backend/grpc-server/src/configs.rs
+++ b/backend/grpc-server/src/configs.rs
@@ -56,6 +56,7 @@ impl Config {
                     .try_parsing(true)
                     .separator("__")
                     .list_separator(",")
+                    .with_list_parse_key("proxy.bypass_proxy_urls")
                     .with_list_parse_key("redis.cluster_urls")
                     .with_list_parse_key("database.tenants"),
             )


### PR DESCRIPTION

## Description
Fixes environment variable parsing for `proxy.bypass_proxy_urls` by adding it to the list parse keys configuration. Enables JSON array format in environment variables for Kubernetes deployments.

## Motivation and Context
The `bypass_proxy_urls` field is required but fails when set via environment variables like `CS__PROXY__BYPASS_PROXY_URLS="localhost,local"` with error: `expected a sequence`. This breaks Kubernetes deployments where config is provided via environment variables.


### Additional Changes
- [ ] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables

__Configuration changes:__

- Enables environment variable parsing for `proxy.bypass_proxy_urls` by registering it as a list parse key
- Modified file: `backend/grpc-server/src/configs.rs`


## How did you test it?
Before: `export CS__PROXY__BYPASS_PROXY_URLS="localhost,local"` → Failed with deserialization error
After: Same command → Starts successfully
Backward compatibility: TOML config still works as before
