### PR TITLE
feat: add HTTP health endpoint for Kubernetes probes

### DIFF
--- a/backend/grpc-server/src/app.rs
+++ b/backend/grpc-server/src/app.rs
@@ -136,6 +136,7 @@ impl Service {
             .layer(logging_layer)
             .layer(request_id_layer)
             .layer(propagate_request_id_layer)
+            .route("/health", axum::routing::get(|| async { "health is good" }))
             .merge(health_handler(self.health_check_service))
             .merge(payment_service_handler(self.payments_service));
 


### PR DESCRIPTION
## Description
This PR adds a simple HTTP health endpoint (`GET /health`) to the connector-service to support Kubernetes HTTP health probes when running in HTTP mode. The endpoint returns a static "health is good" response and enables proper health checking for HTTP mode deployments.

__Changes:__

- Added `GET /health` route to the Axum HTTP router in `app.rs`
- Route returns static text response for fast health checking
- Only affects HTTP mode; gRPC mode continues using existing gRPC health checks
 
## Motivation and Context
__Problem:__ When deploying connector-service in HTTP mode, Kubernetes `httpGet` health probes cannot use the existing gRPC health check endpoint (`/grpc.health.v1.Health/Check`) because:

1. The gRPC endpoint only accepts POST requests with specific headers
2. Kubernetes `httpGet` probes only support GET requests
3. This causes health check failures and prevents proper HTTP mode deployments

__Solution:__ Add a simple `GET /health` endpoint that works seamlessly with Kubernetes HTTP probes, following the same pattern used by Hyperswitch.

### Additional Changes
- [ ] This PR modifies the API contract
- [x] This PR modifies application configuration/environment variables

__Files modified:__

- `backend/grpc-server/src/app.rs` - Added HTTP health route to router


## How did you test it?
### Manual Testing:

1. __Started service in HTTP mode:__

   ```bash
   export CS__SERVER__TYPE=http
   cargo run
   ```

2. __Tested health endpoint:__

   ```bash
   curl -v http://localhost:8000/health
   # Expected: HTTP 200 OK, "health is good"
   ```

3. __Verified Kubernetes probe compatibility:__

   ```bash
   # Simulated K8s httpGet probe
   curl -X GET -w "Status: %{http_code}\nTime: %{time_total}s\n" http://localhost:8000/health
   # Expected: Status 200, fast response time
   ```

