### PR TITLE
fix: Sanitize the branch name with Slash for image tag creation

### DIFF
--- a/.github/workflows/docker-to-ghcr-publish.yml
+++ b/.github/workflows/docker-to-ghcr-publish.yml
@@ -39,13 +39,16 @@ jobs:
           COMMIT_SHA=${{ github.sha }}
           SHORT_SHA=${COMMIT_SHA::7}
           
+          # Sanitize the branch name by replacing slashes with hyphens for Docker compatibility.
+          SANITIZED_REF_NAME=$(echo "${{ github.ref_name }}" | sed 's/\//-/g')
+
           # Check if triggered by tag push
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             # Use the tag name directly
             VERSION="${{ github.ref_name }}"
           elif [[ "${{ github.ref_type }}" == "branch" ]] && [[ -n "${{ github.ref_name }}" ]]; then
             # Use the branch name with short SHA
-            VERSION="${{ github.ref_name }}-${SHORT_SHA}"
+            VERSION="${SANITIZED_REF_NAME}-${SHORT_SHA}"
           else
             # Default to commit SHA if not a tag or branch
             VERSION="commit-${SHORT_SHA}"


### PR DESCRIPTION
…shes with hyphens for Docker compatibility

## Description
This change updates the `docker-to-ghcr-publish.yml` workflow to sanitize branch names before they are used in Docker image tags. It replaces any slashes (`/`) in the branch name with hyphens (`-`) to ensure the tag is compatible with Docker's naming conventions.

## Motivation and Context
The CI/CD pipeline was failing for branches that contain slashes (e.g., `feat/some-feature`) because slashes are not valid characters for Docker image tags. This would cause the `docker build` command to fail, preventing images from being built and pushed for these branches.

This change fixes this issue by introducing a sanitization step for the branch name. By converting slashes to hyphens, we ensure that the generated image tag is always valid, regardless of the branch naming convention used. This makes the CI pipeline more robust and reliable.


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?
This change was tested by pushing a commit to the `origin/test/tracing-kafka-vector-load-testing` branch. The GitHub Actions workflow ran successfully, as shown in [this workflow run](https://github.com/juspay/connector-service/actions/runs/16814377159). This confirms that the branch name was correctly sanitized and the Docker image was built and pushed without any issues.
