### PR TITLE
fix: convert _DOT_ to . for audit event nested keys ENV parsing

### DIFF
--- a/backend/common_utils/src/event_publisher.rs
+++ b/backend/common_utils/src/event_publisher.rs
@@ -196,10 +196,13 @@ impl EventPublisher {
 
         // Process static values - log warnings but continue processing
         for (target_path, static_value) in &self.config.static_values {
+            // Replace _DOT_ and _dot_ with . to support nested keys in environment variables
+            let normalized_path = target_path.replace("_DOT_", ".").replace("_dot_", ".");
             let value = serde_json::json!(static_value);
-            if let Err(e) = self.set_nested_value(&mut result, target_path, value) {
+            if let Err(e) = self.set_nested_value(&mut result, &normalized_path, value) {
                 tracing::warn!(
                     target_path = %target_path,
+                    normalized_path = %normalized_path,
                     static_value = %static_value,
                     error = %e,
                     "Failed to set static value, continuing with event processing"


### PR DESCRIPTION
## Description

This PR enables nested static values in audit event configurations via environment variables by replacing the `_DOT_` placeholder with a `.` during parsing.

## Motivation and Context

This change aligns environment variable configuration with the existing TOML functionality, allowing for more flexible and consistent audit event configuration.

### Additional Changes

- [x] This PR modifies application configuration/environment variables
    - Environment variable support: Adds support for _ DOT _ placeholder in audit event
   static values environment variables (e.g.,
  CS__EVENTS__STATIC_VALUES__MESSAGE_DOT_REQ_TYPE=EXTERNAL)
    - File modified: backend/common_utils/src/event_publisher.rs - Added _DOT_
  replacement logic in static values processing

## How did you test it?

I tested this manually by setting the `CS__EVENTS__STATIC_VALUES__MESSAGE_DOT_REQ_TYPE=EXTERNAL` environment variable and verifying that the application generated the correct nested JSON structure in the audit event.
