### PR TITLE
fix: convert _DOT_ to . for audit event nested keys ENV parsing for transformation and extraction

### DIFF
--- a/backend/common_utils/src/event_publisher.rs
+++ b/backend/common_utils/src/event_publisher.rs
@@ -183,9 +183,12 @@ impl EventPublisher {
         // Process transformations
         for (target_path, source_field) in &self.config.transformations {
             if let Some(value) = result.get(source_field).cloned() {
-                if let Err(e) = self.set_nested_value(&mut result, target_path, value) {
+                // Replace _DOT_ and _dot_ with . to support nested keys in environment variables
+                let normalized_path = target_path.replace("_DOT_", ".").replace("_dot_", ".");
+                if let Err(e) = self.set_nested_value(&mut result, &normalized_path, value) {
                     tracing::warn!(
                         target_path = %target_path,
+                        normalized_path = %normalized_path,
                         source_field = %source_field,
                         error = %e,
                         "Failed to set transformation, continuing with event processing"
@@ -213,9 +216,12 @@ impl EventPublisher {
         // Process extraction
         for (target_path, extraction_path) in &self.config.extractions {
             if let Some(value) = self.extract_from_request(&result, extraction_path) {
-                if let Err(e) = self.set_nested_value(&mut result, target_path, value) {
+                // Replace _DOT_ and _dot_ with . to support nested keys in environment variables
+                let normalized_path = target_path.replace("_DOT_", ".").replace("_dot_", ".");
+                if let Err(e) = self.set_nested_value(&mut result, &normalized_path, value) {
                     tracing::warn!(
                         target_path = %target_path,
+                        normalized_path = %normalized_path,
                         extraction_path = %extraction_path,
                         error = %e,
                         "Failed to set extraction, continuing with event processing"


### PR DESCRIPTION
## Description

This PR enables nested static values in audit event configurations via environment variables by replacing the `_DOT_` placeholder with a `.` during parsing for extractions and transformations as well.

## Motivation and Context

This change aligns environment variable configuration with the existing TOML functionality, allowing for more flexible and consistent audit event configuration.

### Additional Changes

- [x] This PR modifies application configuration/environment variables
    - Environment variable support: Adds support for _ DOT _ placeholder in audit event
   static values environment variables (e.g.,
  CS__EVENTS__STATIC_VALUES__MESSAGE_DOT_REQ_TYPE=EXTERNAL)
    - File modified: backend/common_utils/src/event_publisher.rs - Added _DOT_
  replacement logic in static values processing

## How did you test it?

I tested this manually by setting the `CS__EVENTS__STATIC_VALUES__MESSAGE_DOT_REQ_TYPE=EXTERNAL` environment variable and verifying that the application generated the correct nested JSON structure in the audit event.

usage of ENV:

<img width="418" height="362" alt="image" src="https://github.com/user-attachments/assets/327381f3-5479-4287-8bcb-3960ffc19a81" />

received expected nested structure in events:

<img width="530" height="463" alt="image" src="https://github.com/user-attachments/assets/00e6bb9b-27dd-4483-a56a-3837358f6cc2" />

