### PR TITLE
fix: added req_data to session token event params and comprehensive f…

### DIFF
--- a/backend/common_utils/src/events.rs
+++ b/backend/common_utils/src/events.rs
@@ -207,7 +207,10 @@ pub enum FlowName {
     Dsync,
     IncomingWebhook,
     SetupMandate,
+    RepeatPayment,
     CreateOrder,
+    CreateSessionToken,
+    Unknown,
 }
 
 impl FlowName {
@@ -225,7 +228,10 @@ impl FlowName {
             Self::Dsync => "Dsync",
             Self::IncomingWebhook => "IncomingWebhook",
             Self::SetupMandate => "SetupMandate",
+            Self::RepeatPayment => "RepeatPayment",
             Self::CreateOrder => "CreateOrder",
+            Self::CreateSessionToken => "CreateSessionToken",
+            Self::Unknown => "Unknown",
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request enhances the reliability of payment flow processing by correcting event parameter mappings and ensuring audit events are fail-safe.

Key improvements include:
-   Corrected the flow name and `request_id` for session token events.
-   Fixed the `RepeatPayment` flow, which was incorrectly using an `Authorize` fallback.
-   Added missing `FlowName` variants for `RepeatPayment` and `Unknown` to ensure comprehensive flow representation.
-   Updated and completed flow mappings to prevent audit failures.
-   Made the audit event mechanism fail-safe, preventing audit failures from terminating business requests.

## Motivation and Context

Session token creation was using incorrect audit event
  parameters:
  - Hardcoded "session_token_request" instead of actual request ID
  - Missing CreateSessionToken flow name, falling back to Authorize
  - Audit mapping failures could kill business requests with
  "Unknown flow marker type" errors

These changes ensure that all flows are mapped correctly and that the system can gracefully handle audit event failures without disrupting the core payment processing logic.

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables

## How did you test it?

