### PR TITLE
feat: added header support for audit events

### DIFF
--- a/backend/common_utils/src/event_publisher.rs
+++ b/backend/common_utils/src/event_publisher.rs
@@ -221,18 +221,7 @@ impl EventPublisher {
 
         // Process extraction
         for (target_path, extraction_path) in &self.config.extractions {
-            // Support fallback paths separated by |
-            let paths: Vec<&str> = extraction_path.split('|').collect();
-            let mut extracted_value = None;
-            
-            for path in paths {
-                if let Some(value) = self.extract_from_request(&result, path.trim()) {
-                    extracted_value = Some(value);
-                    break; // Use first successful extraction
-                }
-            }
-            
-            if let Some(value) = extracted_value {
+            if let Some(value) = self.extract_from_request(&result, extraction_path) {
                 // Replace _DOT_ and _dot_ with . to support nested keys in environment variables
                 let normalized_path = target_path.replace("_DOT_", ".").replace("_dot_", ".");
                 if let Err(e) = self.set_nested_value(&mut result, &normalized_path, value) {
@@ -261,20 +250,6 @@ impl EventPublisher {
 
         let source = match first_part {
             "req" => event_value.get("request_data")?.clone(),
-            "header" => {
-                let headers = event_value.get("headers")?;
-                let header_name = path_parts.next()?;
-                let header_value = headers.get(header_name)?.as_str()?;
-                
-                // Check if there's a third part (structured header parsing)
-                if let Some(key) = path_parts.next() {
-                    // Parse structured header: "key1:value1,key2:value2"
-                    return self.parse_structured_header(header_value, key);
-                } else {
-                    // Return the raw header value
-                    return Some(serde_json::Value::String(header_value.to_string()));
-                }
-            }
             _ => return None,
         };
 
@@ -284,18 +259,6 @@ impl EventPublisher {
         }
 
         Some(current.clone())
-    }
-
-    fn parse_structured_header(&self, header_value: &str, target_key: &str) -> Option<serde_json::Value> {
-        // Parse "key1:value1,key2:value2" format
-        for pair in header_value.split(',') {
-            if let Some((key, value)) = pair.split_once(':') {
-                if key.trim() == target_key {
-                    return Some(serde_json::Value::String(value.trim().to_string()));
-                }
-            }
-        }
-        None
     }
 
     fn set_nested_value(

--- a/backend/common_utils/src/events.rs
+++ b/backend/common_utils/src/events.rs
@@ -191,7 +191,7 @@ pub struct Event {
     pub request_data: Option<SecretSerdeValue>,
     pub connector_request_data: Option<SecretSerdeValue>,
     pub connector_response_data: Option<SecretSerdeValue>,
-    pub headers: HashMap<String, Secret<String>>,
+    pub headers: HashMap<String, String>,
     #[serde(flatten)]
     pub additional_fields: HashMap<String, SecretSerdeValue>,
     #[serde(flatten)]

--- a/backend/common_utils/src/events.rs
+++ b/backend/common_utils/src/events.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
 use hyperswitch_masking::Secret;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     global_id::{

--- a/backend/common_utils/src/events.rs
+++ b/backend/common_utils/src/events.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use hyperswitch_masking::Secret;
 
 use crate::{
     global_id::{
@@ -190,6 +191,7 @@ pub struct Event {
     pub request_data: Option<SecretSerdeValue>,
     pub connector_request_data: Option<SecretSerdeValue>,
     pub connector_response_data: Option<SecretSerdeValue>,
+    pub headers: HashMap<String, Secret<String>>,
     #[serde(flatten)]
     pub additional_fields: HashMap<String, SecretSerdeValue>,
     #[serde(flatten)]
@@ -256,6 +258,12 @@ impl EventStage {
     }
 }
 
+/// Configuration for unmasked headers in audit logs
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct UnmaskedHeaders {
+    pub keys: Vec<String>,
+}
+
 /// Configuration for events system
 #[derive(Debug, Clone, Deserialize)]
 pub struct EventConfig {
@@ -269,6 +277,8 @@ pub struct EventConfig {
     pub static_values: HashMap<String, String>, // target_path → static_value
     #[serde(default)]
     pub extractions: HashMap<String, String>, // target_path → extraction_path
+    #[serde(default)]
+    pub unmasked_headers: UnmaskedHeaders, // headers allowed in plaintext in audit logs
 }
 
 impl Default for EventConfig {
@@ -281,6 +291,7 @@ impl Default for EventConfig {
             transformations: HashMap::new(),
             static_values: HashMap::new(),
             extractions: HashMap::new(),
+            unmasked_headers: UnmaskedHeaders::default(),
         }
     }
 }

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -76,6 +76,7 @@ use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde_json::json;
 use tracing::field::Empty;
+use std::collections::HashMap;
 
 use crate::shared_metrics as metrics;
 
@@ -99,7 +100,7 @@ impl ToHttpMethod for Method {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EventProcessingParams<'a> {
     pub connector_name: &'a str,
     pub service_name: &'a str,
@@ -109,6 +110,7 @@ pub struct EventProcessingParams<'a> {
     pub request_id: &'a str,
     pub lineage_ids: &'a lineage::LineageIds<'a>,
     pub reference_id: &'a Option<String>,
+    pub headers: Option<HashMap<String, Secret<String>>>,
 }
 
 #[tracing::instrument(
@@ -351,6 +353,7 @@ where
                                 request_data: raw_request_data_clone,
                                 connector_request_data: request_data.map(Secret::new),
                                 connector_response_data: response_data.map(Secret::new),
+                                headers: event_params.headers.clone().unwrap_or_default(),
                                 additional_fields,
                                 lineage_ids,
                             };
@@ -412,6 +415,7 @@ where
                                 request_data: raw_request_data_clone,
                                 connector_request_data: request_data.map(Secret::new),
                                 connector_response_data: response_data.map(Secret::new),
+                                headers: event_params.headers.clone().unwrap_or_default(),
                                 additional_fields,
                                 lineage_ids,
                             };
@@ -472,6 +476,7 @@ where
                                 request_data: raw_request_data_clone,
                                 connector_request_data: request_data.map(Secret::new),
                                 connector_response_data: None,
+                                headers: event_params.headers.clone().unwrap_or_default(),
                                 additional_fields,
                                 lineage_ids,
                             };

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -75,8 +75,8 @@ use interfaces::{
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde_json::json;
-use tracing::field::Empty;
 use std::collections::HashMap;
+use tracing::field::Empty;
 
 use crate::shared_metrics as metrics;
 

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -75,7 +75,6 @@ use interfaces::{
 use once_cell::sync::OnceCell;
 use reqwest::Client;
 use serde_json::json;
-use std::collections::HashMap;
 use tracing::field::Empty;
 
 use crate::shared_metrics as metrics;

--- a/backend/external-services/src/service.rs
+++ b/backend/external-services/src/service.rs
@@ -110,7 +110,7 @@ pub struct EventProcessingParams<'a> {
     pub request_id: &'a str,
     pub lineage_ids: &'a lineage::LineageIds<'a>,
     pub reference_id: &'a Option<String>,
-    pub headers: Option<HashMap<String, Secret<String>>>,
+    pub headers: Option<HashMap<String, String>>,
 }
 
 #[tracing::instrument(

--- a/backend/grpc-server/src/configs.rs
+++ b/backend/grpc-server/src/configs.rs
@@ -99,7 +99,8 @@ impl Config {
                     .with_list_parse_key("redis.cluster_urls")
                     .with_list_parse_key("database.tenants")
                     .with_list_parse_key("log.kafka.brokers")
-                    .with_list_parse_key("events.brokers"),
+                    .with_list_parse_key("events.brokers")
+                    .with_list_parse_key("events.unmasked_headers.keys"),
             )
             .build()?;
 

--- a/backend/grpc-server/src/configs.rs
+++ b/backend/grpc-server/src/configs.rs
@@ -1,7 +1,8 @@
-use std::path::PathBuf;
+use std::{collections::{HashMap, HashSet}, path::PathBuf};
 
 use common_utils::{consts, events::EventConfig};
 use domain_types::types::{Connectors, Proxy};
+use tonic::metadata;
 
 use crate::{error::ConfigurationError, logger::config::Log};
 
@@ -17,6 +18,8 @@ pub struct Config {
     pub events: EventConfig,
     #[serde(default)]
     pub lineage: LineageConfig,
+    #[serde(default)]
+    pub unmasked_headers: HeaderMaskingConfig,
 }
 
 #[derive(Clone, serde::Deserialize, Debug, Default)]
@@ -174,5 +177,131 @@ pub fn workspace_path() -> PathBuf {
         path
     } else {
         PathBuf::from(".")
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HeaderMaskingConfig {
+    keys: HashSet<String>,
+}
+
+impl<'de> serde::Deserialize<'de> for HeaderMaskingConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct Config {
+            keys: Vec<String>,
+        }
+        
+        Config::deserialize(deserializer).map(|config| Self {
+            keys: config
+                .keys
+                .into_iter()
+                .map(|key| key.to_lowercase())
+                .collect(),
+        })
+    }
+}
+
+impl Default for HeaderMaskingConfig {
+    fn default() -> Self {
+        Self {
+            keys: ["content-type", "content-length", "user-agent"]
+                .iter()
+                .map(|&key| key.to_string())
+                .collect(),
+        }
+    }
+}
+
+impl HeaderMaskingConfig {
+    pub fn is_header_unmasked(&self, header_key: &str) -> bool {
+        self.keys.contains(&header_key.to_lowercase())
+    }
+
+    pub fn should_mask_header(&self, header_key: &str) -> bool {
+        !self.is_header_unmasked(header_key)
+    }
+
+    pub fn create_masked_metadata(&self, metadata: metadata::MetadataMap) -> MaskedMetadata {
+        MaskedMetadata::new(metadata, self.clone())
+    }
+}
+
+pub struct MaskedMetadata {
+    owned_metadata: metadata::MetadataMap,
+    masking_config: HeaderMaskingConfig,
+}
+
+impl MaskedMetadata {
+    pub fn new(metadata: metadata::MetadataMap, config: HeaderMaskingConfig) -> Self {
+        Self {
+            owned_metadata: metadata,
+            masking_config: config,
+        }
+    }
+
+    pub fn get_masked_metadata(&self) -> HashMap<String, hyperswitch_masking::Maskable<String>> {
+        self.owned_metadata
+            .iter()
+            .filter_map(|entry| self.process_metadata_entry(entry))
+            .collect()
+    }
+
+    pub fn get_metadata_value(&self, key: &str) -> Option<String> {
+        self.owned_metadata
+            .get(key)
+            .and_then(|value| value.to_str().ok())
+            .map(String::from)
+    }
+
+    pub fn get_metadata_as_secret(&self, key: &str) -> Option<hyperswitch_masking::Secret<String>> {
+        self.get_metadata_value(key).map(hyperswitch_masking::Secret::new)
+    }
+    
+    pub(crate) fn get_raw_metadata(&self) -> &metadata::MetadataMap {
+        &self.owned_metadata
+    }
+}
+
+impl MaskedMetadata {
+    fn process_metadata_entry(&self, entry: metadata::KeyAndValueRef<'_>) -> Option<(String, hyperswitch_masking::Maskable<String>)> {
+        let header_key = self.extract_header_key(&entry);
+        
+        match entry {
+            metadata::KeyAndValueRef::Ascii(_, value) => value
+                .to_str()
+                .ok()
+                .map(|text_value| (header_key.clone(), self.process_text_header(&header_key, text_value))),
+            metadata::KeyAndValueRef::Binary(_, value) => Some((
+                header_key.clone(),
+                self.process_binary_header(&header_key, value.as_ref()),
+            )),
+        }
+    }
+
+    fn extract_header_key(&self, entry: &metadata::KeyAndValueRef<'_>) -> String {
+        match entry {
+            metadata::KeyAndValueRef::Ascii(key, _) => key.as_str().to_string(),
+            metadata::KeyAndValueRef::Binary(key, _) => key.as_str().to_string(),
+        }
+    }
+
+    fn process_text_header(&self, header_key: &str, value: &str) -> hyperswitch_masking::Maskable<String> {
+        if self.masking_config.is_header_unmasked(header_key) {
+            hyperswitch_masking::Maskable::new(value.to_string())
+        } else {
+            hyperswitch_masking::Maskable::new("**MASKED**".to_string())
+        }
+    }
+
+    fn process_binary_header(&self, header_key: &str, value: &[u8]) -> hyperswitch_masking::Maskable<String> {
+        if self.masking_config.is_header_unmasked(header_key) {
+            hyperswitch_masking::Maskable::new(base64::encode(value))
+        } else {
+            hyperswitch_masking::Maskable::new("**MASKED-BINARY**".to_string())
+        }
     }
 }

--- a/backend/grpc-server/src/server/disputes.rs
+++ b/backend/grpc-server/src/server/disputes.rs
@@ -104,17 +104,15 @@ impl DisputeService for Disputes {
             request,
             &service_name,
             self.config.clone(),
-            |request, metadata_payload| {
+            |payload, metadata_payload, _extensions| {
                 let service_name = service_name.clone();
                 async move {
-                    let metadata = request.metadata().clone();
-                    let payload = request.into_inner();
                     let utils::MetadataPayload {
                         connector,
-                        request_id,
-                        lineage_ids,
+                        ref request_id,
+                        ref lineage_ids,
                         connector_auth_type,
-                        reference_id,
+                        ref reference_id,
                         ..
                     } = metadata_payload;
                     let connector_data: ConnectorData<DefaultPCIHolder> =
@@ -153,10 +151,7 @@ impl DisputeService for Disputes {
                         request: dispute_data,
                         response: Err(ErrorResponse::default()),
                     };
-                    let headers = utils::extract_headers_with_masking(
-                        &metadata,
-                        &self.config.events.unmasked_headers.keys,
-                    );
+                    let headers = metadata_payload.get_masked_metadata();
                     let event_params = external_services::service::EventProcessingParams {
                         connector_name: &connector.to_string(),
                         service_name: &service_name,
@@ -229,8 +224,8 @@ impl DisputeService for Disputes {
             request,
             &service_name,
             self.config.clone(),
-            |request, _metadata_payload| async {
-                let _payload = request.into_inner();
+            |payload, _metadata_payload, _extensions| async {
+                let _payload = payload;
                 let response = DisputeResponse {
                     ..Default::default()
                 };
@@ -303,17 +298,15 @@ impl DisputeService for Disputes {
             request,
             &service_name,
             self.config.clone(),
-            |request, metadata_payload| {
+            |payload, metadata_payload, _extensions| {
                 let service_name = service_name.clone();
                 async move {
-                    let metadata = request.metadata().clone();
-                    let payload = request.into_inner();
                     let utils::MetadataPayload {
                         connector,
-                        request_id,
-                        lineage_ids,
+                        ref request_id,
+                        ref lineage_ids,
                         connector_auth_type,
-                        reference_id,
+                        ref reference_id,
                         ..
                     } = metadata_payload;
 
@@ -352,10 +345,7 @@ impl DisputeService for Disputes {
                         response: Err(ErrorResponse::default()),
                     };
 
-                    let headers = utils::extract_headers_with_masking(
-                        &metadata,
-                        &self.config.events.unmasked_headers.keys,
-                    );
+                    let headers = metadata_payload.get_masked_metadata();
                     let event_params = external_services::service::EventProcessingParams {
                         connector_name: &connector.to_string(),
                         service_name: &service_name,
@@ -426,7 +416,7 @@ impl DisputeService for Disputes {
             request,
             &service_name,
             self.config.clone(),
-            |request, metadata_payload| {
+            |request, metadata_payload, _extensions| {
                 async move {
                     let connector = metadata_payload.connector;
                     let connector_auth_details = metadata_payload.connector_auth_type;

--- a/backend/grpc-server/src/server/disputes.rs
+++ b/backend/grpc-server/src/server/disputes.rs
@@ -134,7 +134,9 @@ impl DisputeService for Disputes {
                         payload.clone(),
                         self.config.connectors.clone(),
                     ))
-                    .map_err(|e| e.into_grpc_status())?;
+                    .map_err(
+                        |e: error_stack::Report<ApplicationErrorResponse>| e.into_grpc_status(),
+                    )?;
 
                     let connector_auth_details = connector_auth_type;
 
@@ -150,6 +152,10 @@ impl DisputeService for Disputes {
                         request: dispute_data,
                         response: Err(ErrorResponse::default()),
                     };
+                    let headers = crate::utils::extract_headers_with_masking(
+                        &metadata,
+                        &self.config.events.unmasked_headers.keys,
+                    );
                     let event_params = external_services::service::EventProcessingParams {
                         connector_name: &connector.to_string(),
                         service_name: &service_name,
@@ -161,6 +167,7 @@ impl DisputeService for Disputes {
                         request_id: &request_id,
                         lineage_ids: &lineage_ids,
                         reference_id: &reference_id,
+                        headers: Some(headers),
                     };
 
                     let response = external_services::service::execute_connector_processing_step(
@@ -343,6 +350,10 @@ impl DisputeService for Disputes {
                         response: Err(ErrorResponse::default()),
                     };
 
+                    let headers = crate::utils::extract_headers_with_masking(
+                        &metadata,
+                        &self.config.events.unmasked_headers.keys,
+                    );
                     let event_params = external_services::service::EventProcessingParams {
                         connector_name: &connector.to_string(),
                         service_name: &service_name,
@@ -354,6 +365,7 @@ impl DisputeService for Disputes {
                         request_id: &request_id,
                         lineage_ids: &lineage_ids,
                         reference_id: &reference_id,
+                        headers: Some(headers),
                     };
 
                     let response = external_services::service::execute_connector_processing_step(

--- a/backend/grpc-server/src/server/disputes.rs
+++ b/backend/grpc-server/src/server/disputes.rs
@@ -107,6 +107,7 @@ impl DisputeService for Disputes {
             |request, metadata_payload| {
                 let service_name = service_name.clone();
                 async move {
+                    let metadata = request.metadata().clone();
                     let payload = request.into_inner();
                     let utils::MetadataPayload {
                         connector,
@@ -152,7 +153,7 @@ impl DisputeService for Disputes {
                         request: dispute_data,
                         response: Err(ErrorResponse::default()),
                     };
-                    let headers = crate::utils::extract_headers_with_masking(
+                    let headers = utils::extract_headers_with_masking(
                         &metadata,
                         &self.config.events.unmasked_headers.keys,
                     );
@@ -305,6 +306,7 @@ impl DisputeService for Disputes {
             |request, metadata_payload| {
                 let service_name = service_name.clone();
                 async move {
+                    let metadata = request.metadata().clone();
                     let payload = request.into_inner();
                     let utils::MetadataPayload {
                         connector,
@@ -350,7 +352,7 @@ impl DisputeService for Disputes {
                         response: Err(ErrorResponse::default()),
                     };
 
-                    let headers = crate::utils::extract_headers_with_masking(
+                    let headers = utils::extract_headers_with_masking(
                         &metadata,
                         &self.config.events.unmasked_headers.keys,
                     );

--- a/backend/grpc-server/src/server/payments.rs
+++ b/backend/grpc-server/src/server/payments.rs
@@ -1680,7 +1680,7 @@ impl PaymentService for Payments {
             request,
             &service_name,
             self.config.clone(),
-            |request, metadata_payload: utils::MetadataPayload| {
+            |request, metadata_payload| {
                 let service_name = service_name.clone();
                 Box::pin(async move {
                     let (connector, request_id) =

--- a/backend/grpc-server/src/server/refunds.rs
+++ b/backend/grpc-server/src/server/refunds.rs
@@ -117,7 +117,7 @@ impl RefundService for Refunds {
             request,
             &service_name,
             self.config.clone(),
-            |request, metadata_payload| async move {
+            |request, metadata_payload, _extensions| async move {
                 let connector = metadata_payload.connector;
                 let connector_auth_details = metadata_payload.connector_auth_type;
                 let payload = request.into_inner();

--- a/backend/grpc-server/src/utils.rs
+++ b/backend/grpc-server/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, {str::FromStr}, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use common_utils::{
     consts::{self, X_API_KEY, X_API_SECRET, X_AUTH, X_AUTH_KEY_MAP, X_KEY1, X_KEY2},
@@ -517,13 +517,12 @@ macro_rules! implement_connector_operation {
 }
 }
 
-
 pub fn extract_headers_with_masking(
     metadata: &metadata::MetadataMap,
-    unmasked_keys: &[String]
+    unmasked_keys: &[String],
 ) -> HashMap<String, hyperswitch_masking::Secret<String>> {
     let mut headers = HashMap::new();
-    
+
     for key_and_value in metadata.iter() {
         if let metadata::KeyAndValueRef::Ascii(key, value) = key_and_value {
             let key_str = key.as_str().to_lowercase();
@@ -534,10 +533,10 @@ pub fn extract_headers_with_masking(
                 // Mask all other headers
                 "**MASKED**".to_string()
             };
-            
+
             headers.insert(
                 key.as_str().to_string(),
-                hyperswitch_masking::Secret::new(header_value)
+                hyperswitch_masking::Secret::new(header_value),
             );
         }
     }

--- a/config/development.toml
+++ b/config/development.toml
@@ -86,5 +86,5 @@ field_prefix = "lineage_"
 "message.req_type" = "EXTERNAL"
 "message.log_type" = "API_CALL"
 
-[events.unmasked_headers]
-keys = ["x-reference-id", "x-request-id", "x-lineage-ids"]
+[unmasked_headers]
+keys = ["x-reference-id", "x-request-id", "x-lineage-ids"] #other?

--- a/config/development.toml
+++ b/config/development.toml
@@ -77,6 +77,7 @@ field_prefix = "lineage_"
 "message.stage" = "stage"
 "message.req_body" = "connector_request_data"
 "message.res_body" = "connector_response_data"
+"udf_txn_uuid" = "reference_id"
 
 [events.static_values]
 "hostname" = "connector-service"
@@ -84,9 +85,6 @@ field_prefix = "lineage_"
 "category" = "OUTGOING_API"
 "message.req_type" = "EXTERNAL"
 "message.log_type" = "API_CALL"
-
-[events.extractions]
-"udf_txn_uuid" = "req.merchant_order_reference_id|reference_id"
 
 [events.unmasked_headers]
 keys = ["x-reference-id", "x-request-id", "x-lineage-ids"]

--- a/config/development.toml
+++ b/config/development.toml
@@ -86,5 +86,7 @@ field_prefix = "lineage_"
 "message.log_type" = "API_CALL"
 
 [events.extractions]
-"udf_txn_uuid" = "req.metadata.udf_txn_uuid"
-"x-request-id" = "req.metadata.x-request-id"
+"udf_txn_uuid" = "req.merchant_order_reference_id|reference_id"
+
+[events.unmasked_headers]
+keys = ["x-reference-id", "x-request-id", "x-lineage-ids"]


### PR DESCRIPTION
## Description

This pull request introduces enhanced audit logging capabilities by implementing gRPC header extraction, masking. These changes ensure that header is logged in audit events.

Key features include:

- __Header Extraction and Masking__: All gRPC headers are now captured in audit events. By default, header values are masked for security, with a configurable whitelist for selective unmasking.

## Motivation and Context

The primary motivation for this change is to enhance audit events, with masked header.

### Additional Changes

- [x] This PR modifies application configuration/environment variables

The following configuration files were modified:

- `config/development.toml`: Added `[events.extractions]` and `[events.unmasked_headers]` sections to control the new functionality.

__Configuration Example:__

```toml
[events.unmasked_headers]
keys = ["x-reference-id", "x-request-id", "x-lineage-ids"]
```

## How did you test it?

The functionality was validated by sending a `grpcurl` request to the `PaymentService/Get` endpoint and verifying the resulting event in Kafka.

__1. Configuration Used (`config/development.toml`):__

```toml
[events.unmasked_headers]
keys = ["x-reference-id", "x-request-id", "x-lineage-ids"]
```

__2. Request Sent:__

```sh
grpcurl -plaintext -proto backend/grpc-api-types/proto/services.proto -import-path  backend/grpc-api-types/proto -d '{"transaction_id":{"id":"txn_1234567890"},"request_ref_id":{"id":"payment_1234567890"}}' -H "x-tenant-id: public" -H "x-request-id:   req1234" -H "x-connector: razorpay" -H "x-merchant-id: test_merchant" -H "x-auth:   body-key" -H "x-api-key: test_key" -H "x-key1: 32d46916-4bc9-423b-88d5-35558b59a1b3"  -H "x-reference-id: fallback_merchant_order_ref_12345" -H "x-resource-id:   fallback_resource_98765" -H "x-lineage-ids:merchant_id=test_merchant&tenant_id=public&environment=sandbox&region=in-west-1&version=v2.1" localhost:8000  ucs.v2.PaymentService/Get
```

__3. Event Received in Kafka:__ The following event was captured, confirming the changes work as expected:

```json
{
	"action": "Psync",
	"category": "OUTGOING_API",
	"connector": "razorpay",
	"connector_request_data": null,
	"connector_response_data": {
		"message": "no Route matched with those values"
	},
	"entity": "Psync",
	"flow_type": "Psync",
	"gateway": "razorpay",
	"headers": {
		"content-type": "**MASKED**",
		"grpc-accept-encoding": "**MASKED**",
		"te": "**MASKED**",
		"user-agent": "**MASKED**",
		"x-api-key": "**MASKED**",
		"x-auth": "**MASKED**",
		"x-connector": "**MASKED**",
		"x-key1": "**MASKED**",
		"x-lineage-ids": "merchant_id=test_merchant&tenant_id=public&environment=sandbox&region=in-west-1&version=v2.1",
		"x-merchant-id": "**MASKED**",
		"x-reference-id": "fallback_merchant_order_ref_12345",
		"x-request-id": "req1234",
		"x-resource-id": "**MASKED**",
		"x-tenant-id": "**MASKED**"
	},
	"hostname": "connector-service",
	"latency": 474,
	"lineage_environment": "sandbox",
	"lineage_merchant_id": "test_merchant",
	"lineage_region": "in-west-1",
	"lineage_tenant_id": "public",
	"lineage_version": "v2.1",
	"message": {
		"latency": 474,
		"log_type": "API_CALL",
		"req_body": null,
		"req_type": "EXTERNAL",
		"request_time": 1757261785,
		"res_body": {
			"message": "no Route matched with those values"
		},
		"res_code": 404,
		"stage": "ConnectorCall",
		"url": "https://api.razorpay.com/v1/orders/payment_1234567890/payments"
	},
	"reference_id": "fallback_merchant_order_ref_12345",
	"request_data": {
		"request_ref_id": {
			"id_type": {
				"Id": "payment_1234567890"
			}
		},
		"transaction_id": {
			"id_type": {
				"Id": "txn_1234567890"
			}
		}
	},
	"request_id": "req1234",
	"schema_version": "V2",
	"stage": "ConnectorCall",
	"status_code": 404,
	"timestamp": 1757261785,
	"udf_txn_uuid": "fallback_merchant_order_ref_12345",
	"url": "https://api.razorpay.com/v1/orders/payment_1234567890/payments"
}
```

__Verification Points:__

- ✅ __Header Masking__: Headers not in the `unmasked_headers` list were correctly masked, while `lineage-id`, `x-request-id`, and `x-resource-id` remained visible.
