### PR TITLE
chore: Add amount conversion wrapper and integrity checks for Xendit

### DIFF
--- a/backend/connector-integration/src/connectors/macros.rs
+++ b/backend/connector-integration/src/connectors/macros.rs
@@ -869,3 +869,37 @@ macro_rules! expand_imports {
     };
 }
 pub(crate) use expand_imports;
+
+macro_rules! create_amount_converter_wrapper {
+    (connector_name: $connector_name:ident, amount_type: $amount_type:ty) => {
+        paste::paste! {
+            #[derive(Default, Debug, Clone, Copy, PartialEq)]
+            pub struct [<$connector_name AmountConvertor>];
+
+            impl [<$connector_name AmountConvertor>] {
+                pub fn convert_amount(
+                    amount: common_utils::types::MinorUnit,
+                    currency: common_enums::Currency,
+                ) -> Result<common_utils::types::$amount_type, error_stack::Report<errors::ConnectorError>> {
+                    domain_types::utils::convert_amount(
+                        &common_utils::types::[<$amount_type ForConnector>],
+                        amount,
+                        currency,
+                    )
+                }
+
+                pub fn convert_back_amount_to_minor_units(
+                    amount: common_utils::types::$amount_type,
+                    currency: common_enums::Currency,
+                ) -> Result<common_utils::types::MinorUnit, error_stack::Report<errors::ConnectorError>> {
+                    domain_types::utils::convert_back_amount_to_minor_units(
+                        &common_utils::types::[<$amount_type ForConnector>],
+                        amount,
+                        currency,
+                    )
+                }
+            }
+        }
+    };
+}
+pub(crate) use create_amount_converter_wrapper;

--- a/backend/connector-integration/src/connectors/macros.rs
+++ b/backend/connector-integration/src/connectors/macros.rs
@@ -877,7 +877,7 @@ macro_rules! create_amount_converter_wrapper {
             pub struct [<$connector_name AmountConvertor>];
 
             impl [<$connector_name AmountConvertor>] {
-                pub fn convert_amount(
+                pub fn convert(
                     amount: common_utils::types::MinorUnit,
                     currency: common_enums::Currency,
                 ) -> Result<common_utils::types::$amount_type, error_stack::Report<errors::ConnectorError>> {
@@ -888,7 +888,7 @@ macro_rules! create_amount_converter_wrapper {
                     )
                 }
 
-                pub fn convert_back_amount_to_minor_units(
+                pub fn convert_back(
                     amount: common_utils::types::$amount_type,
                     currency: common_enums::Currency,
                 ) -> Result<common_utils::types::MinorUnit, error_stack::Report<errors::ConnectorError>> {

--- a/backend/connector-integration/src/connectors/xendit.rs
+++ b/backend/connector-integration/src/connectors/xendit.rs
@@ -35,9 +35,9 @@ use interfaces::{
 };
 use serde::Serialize;
 use transformers::{
-    self as xendit, RefundResponse, RefundResponse as RefundSyncResponse, XenditErrorResponse,
-    XenditPaymentResponse, XenditPaymentsCaptureRequest, XenditPaymentsRequest, 
-    XenditRefundRequest, XenditResponse, XenditCaptureResponse
+    self as xendit, RefundResponse, RefundResponse as RefundSyncResponse, XenditCaptureResponse,
+    XenditErrorResponse, XenditPaymentResponse, XenditPaymentsCaptureRequest,
+    XenditPaymentsRequest, XenditRefundRequest, XenditResponse,
 };
 
 use super::macros;

--- a/backend/connector-integration/src/connectors/xendit.rs
+++ b/backend/connector-integration/src/connectors/xendit.rs
@@ -205,17 +205,6 @@ impl<
 }
 
 macros::create_amount_converter_wrapper!(connector_name: Xendit, amount_type: FloatMajorUnit);
-impl<
-        T: PaymentMethodDataTypes
-            + std::fmt::Debug
-            + std::marker::Sync
-            + std::marker::Send
-            + 'static
-            + Serialize,
-    > connector_types::PaymentTokenV2<T> for Xendit<T>
-{
-}
-
 macros::create_all_prerequisites!(
     connector_name:  Xendit,
     generic_type: T,

--- a/backend/connector-integration/src/connectors/xendit.rs
+++ b/backend/connector-integration/src/connectors/xendit.rs
@@ -36,8 +36,8 @@ use interfaces::{
 use serde::Serialize;
 use transformers::{
     self as xendit, RefundResponse, RefundResponse as RefundSyncResponse, XenditErrorResponse,
-    XenditPaymentResponse, XenditPaymentResponse as XenditCaptureResponse,
-    XenditPaymentsCaptureRequest, XenditPaymentsRequest, XenditRefundRequest, XenditResponse,
+    XenditPaymentResponse, XenditPaymentsCaptureRequest, XenditPaymentsRequest, 
+    XenditRefundRequest, XenditResponse, XenditCaptureResponse
 };
 
 use super::macros;

--- a/backend/connector-integration/src/connectors/xendit.rs
+++ b/backend/connector-integration/src/connectors/xendit.rs
@@ -186,6 +186,7 @@ impl<
 {
 }
 
+macros::create_amount_converter_wrapper!(connector_name: Xendit, amount_type: FloatMajorUnit);
 macros::create_all_prerequisites!(
     connector_name:  Xendit,
     generic_type: T,

--- a/backend/connector-integration/src/connectors/xendit/transformers.rs
+++ b/backend/connector-integration/src/connectors/xendit/transformers.rs
@@ -359,7 +359,7 @@ impl<
         let router_data = &item.router_data;
 
         let currency = item.router_data.request.currency;
-        let amount = XenditAmountConvertor::convert_amount(
+        let amount = XenditAmountConvertor::convert(
             router_data.request.minor_amount,
             router_data.request.currency,
         )
@@ -484,7 +484,7 @@ impl<
 
         let response_integrity_object = match response.amount {
             Some(amount) => {
-                let response_amount = XenditAmountConvertor::convert_back_amount_to_minor_units(
+                let response_amount = XenditAmountConvertor::convert_back(
                     amount,
                     response.currency,
                 )?;
@@ -565,7 +565,7 @@ impl<F> TryFrom<ResponseRouterData<XenditResponse, Self>>
                 let response_integrity_object = match payment_response.amount {
                     Some(amount) => {
                         let response_amount =
-                            XenditAmountConvertor::convert_back_amount_to_minor_units(
+                            XenditAmountConvertor::convert_back(
                                 amount,
                                 payment_response.currency,
                             )?;
@@ -636,7 +636,7 @@ impl<
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = XenditAmountConvertor::convert_amount(
+        let amount = XenditAmountConvertor::convert(
             item.router_data.request.minor_amount_to_capture,
             item.router_data.request.currency,
         )
@@ -736,7 +736,7 @@ impl<
             T,
         >,
     ) -> Result<Self, Self::Error> {
-        let amount = XenditAmountConvertor::convert_amount(
+        let amount = XenditAmountConvertor::convert(
             item.router_data.request.minor_refund_amount,
             item.router_data.request.currency,
         )
@@ -780,7 +780,7 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
 
         let response_currency = Currency::from_str(response.currency.to_uppercase().as_str())
             .change_context(errors::ConnectorError::ParsingFailed)?;
-        let response_amount = XenditAmountConvertor::convert_back_amount_to_minor_units(
+        let response_amount = XenditAmountConvertor::convert_back(
             response.amount,
             response_currency,
         )?;

--- a/backend/connector-integration/src/connectors/xendit/transformers.rs
+++ b/backend/connector-integration/src/connectors/xendit/transformers.rs
@@ -311,15 +311,15 @@ fn map_payment_response_to_attempt_status(
     }
 }
 
-fn map_capture_response_to_attempt_status(
-    response: &XenditCaptureResponse,
-) -> common_enums::AttemptStatus {
-    match response.status {
-        PaymentStatus::Failed => common_enums::AttemptStatus::Failure,
-        PaymentStatus::Succeeded | PaymentStatus::Verified => common_enums::AttemptStatus::Charged,
-        PaymentStatus::Pending => common_enums::AttemptStatus::Pending,
-        PaymentStatus::RequiresAction => common_enums::AttemptStatus::AuthenticationPending,
-        PaymentStatus::AwaitingCapture => common_enums::AttemptStatus::Authorized,
+impl From<PaymentStatus> for common_enums::AttemptStatus {
+    fn from(status: PaymentStatus) -> Self {
+        match status {
+            PaymentStatus::Failed => common_enums::AttemptStatus::Failure,
+            PaymentStatus::Succeeded | PaymentStatus::Verified => common_enums::AttemptStatus::Charged,
+            PaymentStatus::Pending => common_enums::AttemptStatus::Pending,
+            PaymentStatus::RequiresAction => common_enums::AttemptStatus::AuthenticationPending,
+            PaymentStatus::AwaitingCapture => common_enums::AttemptStatus::Authorized,
+        }
     }
 }
 
@@ -653,7 +653,7 @@ impl<F> TryFrom<ResponseRouterData<XenditCaptureResponse, Self>>
     fn try_from(
         item: ResponseRouterData<XenditCaptureResponse, Self>,
     ) -> Result<Self, Self::Error> {
-        let status = map_capture_response_to_attempt_status(&item.response);
+        let status = common_enums::AttemptStatus::from(item.response.status);
         let response = if status == common_enums::AttemptStatus::Failure {
             Err(ErrorResponse {
                 code: item

--- a/backend/connector-integration/src/connectors/xendit/transformers.rs
+++ b/backend/connector-integration/src/connectors/xendit/transformers.rs
@@ -484,10 +484,8 @@ impl<
 
         let response_integrity_object = match response.amount {
             Some(amount) => {
-                let response_amount = XenditAmountConvertor::convert_back(
-                    amount,
-                    response.currency,
-                )?;
+                let response_amount =
+                    XenditAmountConvertor::convert_back(amount, response.currency)?;
                 Some(AuthoriseIntegrityObject {
                     amount: response_amount,
                     currency: response.currency,
@@ -565,10 +563,7 @@ impl<F> TryFrom<ResponseRouterData<XenditResponse, Self>>
                 let response_integrity_object = match payment_response.amount {
                     Some(amount) => {
                         let response_amount =
-                            XenditAmountConvertor::convert_back(
-                                amount,
-                                payment_response.currency,
-                            )?;
+                            XenditAmountConvertor::convert_back(amount, payment_response.currency)?;
                         Some(PaymentSynIntegrityObject {
                             amount: response_amount,
                             currency: payment_response.currency,
@@ -780,10 +775,8 @@ impl<F> TryFrom<ResponseRouterData<RefundResponse, Self>>
 
         let response_currency = Currency::from_str(response.currency.to_uppercase().as_str())
             .change_context(errors::ConnectorError::ParsingFailed)?;
-        let response_amount = XenditAmountConvertor::convert_back(
-            response.amount,
-            response_currency,
-        )?;
+        let response_amount =
+            XenditAmountConvertor::convert_back(response.amount, response_currency)?;
 
         let response_integrity_object = {
             Some(RefundIntegrityObject {

--- a/backend/connector-integration/src/connectors/xendit/transformers.rs
+++ b/backend/connector-integration/src/connectors/xendit/transformers.rs
@@ -315,7 +315,9 @@ impl From<PaymentStatus> for common_enums::AttemptStatus {
     fn from(status: PaymentStatus) -> Self {
         match status {
             PaymentStatus::Failed => common_enums::AttemptStatus::Failure,
-            PaymentStatus::Succeeded | PaymentStatus::Verified => common_enums::AttemptStatus::Charged,
+            PaymentStatus::Succeeded | PaymentStatus::Verified => {
+                common_enums::AttemptStatus::Charged
+            }
             PaymentStatus::Pending => common_enums::AttemptStatus::Pending,
             PaymentStatus::RequiresAction => common_enums::AttemptStatus::AuthenticationPending,
             PaymentStatus::AwaitingCapture => common_enums::AttemptStatus::Authorized,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces a new macro create_amount_converter_wrapper to standardize amount conversions within connectors. It also refactors the Xendit connector to use this new macro and adds data integrity checks for amount and currency in authorize, sync, and refund flows.

Updated capture response handling in xendit to match with hyperswitch.

Updated Xendit test file.

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->


### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
