### PR TITLE
chore(core): removing debug logging which is set manually

### DIFF
--- a/backend/grpc-server/src/main.rs
+++ b/backend/grpc-server/src/main.rs
@@ -11,10 +11,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         [grpc_server::service_name!(), "grpc_server", "tower_http"],
     );
 
-    // TEMP: Initialize router_env logger to see injector logs
-    std::env::set_var("ROUTER_ENV_LOG_LEVEL", "debug");
-    // Try to initialize router_env logger if available
-
     let metrics_server = app::metrics_server_builder(config.clone());
     let server = app::server_builder(config);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless it is an obvious bug or documentation fix
that will have little conversation).
-->

Manually setting an environment variable (ROUTER_ENV_LOG_LEVEL) at runtime just to enable debug logging, need to be removed

### Additional Changes
- [ ] This PR modifies the API contract
- [ ] This PR modifies application configuration/environment variables
<!--
Provide links to the files with corresponding changes.

Following are the paths where you can find config files:
1. `config`
-->

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
```
[INFO] log_utils: Using console filtering directive: WARN,tracing_kafka=TRACE,grpc_server=TRACE,log_utils=TRACE,grpc_server=TRACE,rust_grpc_client=TRACE,build_info=TRACE,connector_integration=TRACE,domain_types=TRACE,ucs_cards=TRACE,tower_http=TRACE,ucs_common_enums=TRACE,ucs_common_utils=TRACE,external_services=TRACE,grpc_api_types=TRACE,interfaces=TRACE
  2025-09-11T07:55:20.923414Z  INFO grpc_server::logger::setup: Logging subsystem initialized, service_name: "grpc-server", build_version: "-7bdb34f-2025-09-11T04:07:24.000000000Z", kafka_logging_enabled: false
    at backend/grpc-server/src/logger/setup.rs:157

  2025-09-11T07:55:20.923573Z  INFO grpc_server::configs: binding the server, loc: 127.0.0.1:8080
    at backend/grpc-server/src/configs.rs:165

  2025-09-11T07:55:20.923947Z  INFO grpc_server::app: starting connector service, host: 127.0.0.1, port: 8000, type: Grpc
    at backend/grpc-server/src/app.rs:71

  2025-09-11T07:55:20.923988Z  INFO grpc_server::app: Global EventPublisher initialized successfully
    at backend/grpc-server/src/app.rs:109

  2025-09-11T08:00:24.956346Z  INFO tower_http::trace::on_request: started processing request
    at /home/shivanshmathur/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.6/src/trace/on_request.rs:80
    in grpc_server::utils::request with uri: /grpc.reflection.v1.ServerReflection/ServerReflectionInfo, version: HTTP/2.0, tenant_id: "tenant"

  2025-09-11T08:00:24.956648Z  INFO tower_http::trace::on_response: finished processing request, latency: 337 μs
    at /home/shivanshmathur/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.6/src/trace/on_response.rs:114
    in grpc_server::utils::request with uri: /grpc.reflection.v1.ServerReflection/ServerReflectionInfo, version: HTTP/2.0, tenant_id: "tenant"

  2025-09-11T08:00:24.972582Z  INFO tower_http::trace::on_request: started processing request
    at /home/shivanshmathur/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.6/src/trace/on_request.rs:80
    in grpc_server::utils::request with uri: /ucs.v2.PaymentService/Authorize, version: HTTP/2.0, tenant_id: "tenant"

  2025-09-11T08:00:24.972895Z  INFO grpc_server::server::payments: PAYMENT_AUTHORIZE_FLOW: initiated
    at backend/grpc-server/src/server/payments.rs:958
    in grpc_server::server::payments::payment_authorize with name: "UCS", service_method: "Authorize", message_: "Golden Log Line (incoming)", flow: "Authorize"
    in grpc_server::utils::request with uri: /ucs.v2.PaymentService/Authorize, version: HTTP/2.0, tenant_id: "tenant"

  2025-09-11T08:00:24.972956Z  INFO grpc_server::utils: Successfully parsed lineage header, parsed_fields: None
```